### PR TITLE
fix: 레이아웃 너비 값, 수치로 변경 및 바텀 네비게이션 높이값 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,9 +5,9 @@ import TopNavigation from './components/TopNavigation.vue';
 </script>
 
 <template>
-  <div class="flex items-center justify-center">
+  <div class="flex items-center justify-center h-screen">
     <div
-      class="bg-ivory flex min-h-screen w-[calc(100vh_*_390_/_844)] justify-center rounded-[10px] px-4 shadow-lg relative"
+      class="bg-ivory flex min-h-screen w-[390px] justify-center rounded-[10px] px-4 shadow-lg relative"
     >
       <!-- 메인 콘텐츠 영역에 상단 패딩 추가 -->
       <div class="w-full pt-16 pb-20">

--- a/src/components/BottomNavigation.vue
+++ b/src/components/BottomNavigation.vue
@@ -1,8 +1,6 @@
 <template>
-  <nav
-    class="fixed bottom-0 bg-ivory w-[calc(100vh_*_390_/_844)] border-gray-200 z-10"
-  >
-    <div class="flex justify-around items-center py-2 pb-5 mx-auto">
+  <nav class="fixed bottom-0 bg-ivory w-[390px] border-gray-200 z-10">
+    <div class="flex justify-around items-center h-22 mx-auto">
       <router-link
         to="/"
         class="flex flex-col items-center no-underline! text-gray-300! transition-all duration-300 flex-1 px-1 py-2"


### PR DESCRIPTION
# 📌 레이아웃 값 수정

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 레이아웃의 너비를 뷰포트로 계산하는 방식에서 특정 수치값(390px)로 수정했습니다.
- 바텀 네비게이션의 스타일을 수정했습니다.(`h-88` = height : 88px)


---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
