### PR TITLE
fix: 자산 연동 API 전 회원가입 요청으로 수정

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -51,4 +51,18 @@ const signup = async signupData => {
   }
 };
 
-export default { checkName, sendCode, verifyCode, signup };
+const login = async loginData => {
+  try {
+    const response = await axiosInstance.post('/api/users/login', {
+      email: loginData.email,
+      password: loginData.password,
+    });
+    // accessToken, refreshToken 저장
+    window.localStorage.setItem('accessToken', response.data.accessToken);
+    window.localStorage.setItem('refreshToken', response.data.refreshToken);
+  } catch {
+    throw new Error('로그인 실패');
+  }
+};
+
+export default { checkName, sendCode, verifyCode, signup, login };

--- a/src/views/login/LoginView.vue
+++ b/src/views/login/LoginView.vue
@@ -148,7 +148,7 @@
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import axiosInstance from '@/api/axios';
+import authApi from '@/api/authApi';
 import AlertModal from '@/components/AlertModal.vue';
 
 const router = useRouter();
@@ -173,17 +173,14 @@ const handleLogin = async () => {
     return;
   }
   try {
-    const response = await axiosInstance.post('/api/users/login', {
+    await authApi.login({
       email: email.value,
       password: password.value,
     });
-    // accessToken, refreshToken 저장
-    window.localStorage.setItem('accessToken', response.data.accessToken);
-    window.localStorage.setItem('refreshToken', response.data.refreshToken);
     // 로그인 성공 시 모달 창 띄우기
     showModal.value = true;
     modalType.value = 'success';
-  } catch (error) {
+  } catch {
     showModal.value = true;
     modalType.value = 'fail';
   }

--- a/src/views/signup/SignupFlowView.vue
+++ b/src/views/signup/SignupFlowView.vue
@@ -15,8 +15,10 @@
     <!-- 설문조사 2 -->
     <SurveyTwoComponent
       v-else-if="currentStep === 'survey2'"
+      :signup-data="allData.signupData"
       @next="handleSurvey2Complete"
       @skip="handleAssetSkip"
+      @error="handleSignupError"
     />
 
     <!-- 자산 선택 -->
@@ -39,8 +41,6 @@
       v-else-if="currentStep === 'character-select'"
       :all-data="allData"
       @complete="handleCharacterSelect"
-      @error="handleSignupError"
-      @success="handleSignupSuccess"
     />
   </div>
 </template>
@@ -67,7 +67,7 @@ const allData = ref({
     email: '',
     password: '',
     nickname: '',
-    choogooMi: '',
+    choogooMi: 'A',
   },
 
   // 설문조사 1 답변
@@ -109,6 +109,7 @@ const handleSurvey2Complete = data => {
     ...allData.value.survey2Data,
     ...data,
   };
+
   currentStep.value = 'asset-select';
 };
 
@@ -153,7 +154,7 @@ const handleSignupError = () => {
       email: '',
       password: '',
       nickname: '',
-      choogooMi: '',
+      choogooMi: 'A',
     },
     survey1Data: {
       age: null,

--- a/src/views/signup/SignupFlowView.vue
+++ b/src/views/signup/SignupFlowView.vue
@@ -48,6 +48,8 @@
 <script setup>
 import { ref } from 'vue';
 
+import authApi from '@/api/authApi';
+
 import AssetConnectComponent from './components/asset/AssetConnectComponent.vue';
 import AssetSelectComponent from './components/asset/AssetSelectComponent.vue';
 import CharacterSelectComponent from './components/character/CharacterSelectComponent.vue';
@@ -103,12 +105,17 @@ const handleSurvey1Complete = data => {
   currentStep.value = 'survey2';
 };
 
-const handleSurvey2Complete = data => {
+const handleSurvey2Complete = async data => {
   // 설문조사 2 데이터를 allData에 누적
   allData.value.survey2Data = {
     ...allData.value.survey2Data,
     ...data,
   };
+  const loginData = {
+    email: allData.value.signupData.email,
+    password: allData.value.signupData.password,
+  };
+  await authApi.login(loginData);
 
   currentStep.value = 'asset-select';
 };
@@ -137,10 +144,7 @@ const handleAssetConnectComplete = () => {
 const handleCharacterSelect = data => {
   // 캐릭터 선택 정보를 allData에 저장
   allData.value.signupData.choogooMi = data.choogooMi;
-};
-
-const handleSignupSuccess = () => {
-  isSignupSuccess.value = true;
+  router.push('/login');
 };
 
 const handleSignupError = () => {

--- a/src/views/signup/components/character/CharacterSelectComponent.vue
+++ b/src/views/signup/components/character/CharacterSelectComponent.vue
@@ -47,33 +47,15 @@
       @close="isModalOpen = false"
       @select="confirmSelection"
     />
-    <AlertModal
-      v-if="isErrorModalOpen"
-      title="오류"
-      message="회원가입 중 문제가 발생했습니다. 다시 시도해주세요."
-      @close="handleError"
-    />
-    <AlertModal
-      v-if="isSuccessModalOpen"
-      title="회원가입"
-      message="회원가입이 완료되었습니다."
-      @close="handleSuccess"
-    />
   </div>
 </template>
 
 <script setup>
 import { computed, ref } from 'vue';
-import { useRouter } from 'vue-router';
-
-import authApi from '@/api/authApi';
-import AlertModal from '@/components/AlertModal.vue';
 
 import { CHOOGOOMI_CHARACTERS } from '../../constants/choogoomiList';
 import CharacterCard from './CharacterCard.vue';
 import CharacterDetailModal from './CharacterDetailModal.vue';
-
-const router = useRouter();
 
 // Props 정의
 const props = defineProps({
@@ -82,12 +64,10 @@ const props = defineProps({
 });
 
 // Emit 정의
-const emit = defineEmits(['complete', 'error']);
+const emit = defineEmits(['complete']);
 
 const selected = ref(null);
 const isModalOpen = ref(false);
-const isErrorModalOpen = ref(false);
-const isSuccessModalOpen = ref(false);
 const isSigningUp = ref(false);
 
 const profileImage = ref(null);
@@ -106,46 +86,25 @@ const confirmSelection = async () => {
   if (isSigningUp.value) return; // 중복 요청 방지
 
   isSigningUp.value = true;
-  try {
-    const selectedChar = CHOOGOOMI_CHARACTERS.find(
-      char => char.choogoomiId === selected.value
-    );
 
-    // 최종 회원가입 데이터 구성 (누적된 모든 데이터 포함)
-    const finalSignupData = {
-      ...props.allData.signupData,
-      profileImage: profileImage.value,
-      choogooMi: selectedChar.choogoomiId,
-    };
-    // 회원가입 API 호출
-    await authApi.signup(finalSignupData);
+  const selectedChar = CHOOGOOMI_CHARACTERS.find(
+    char => char.choogoomiId === selected.value
+  );
 
-    // 회원가입 성공 시 성공 모달 표시
-    isSuccessModalOpen.value = true;
-  } catch (error) {
-    console.error('회원가입 실패:', error);
-    // 에러 처리 - 에러 모달 표시
-    isErrorModalOpen.value = true;
-  } finally {
-    isModalOpen.value = false;
-    isSigningUp.value = false;
-  }
-};
+  // 최종 회원가입 데이터 구성 (누적된 모든 데이터 포함)
+  const finalSignupData = {
+    ...props.allData.signupData,
+    profileImage: profileImage.value,
+    choogooMi: selectedChar.choogoomiId,
+  };
 
-// 선택된 캐릭터 정보
-const selectedCharacter = computed(() => {
-  return selected.value !== null
-    ? CHOOGOOMI_CHARACTERS.find(char => char.choogoomiId === selected.value)
-    : null;
-});
+  // 기존 회원가입 API 호출 대신 console.log로 변경
+  console.log('캐릭터 선택 완료 - 회원가입 데이터:', finalSignupData);
+  console.log('선택된 캐릭터:', selectedChar);
 
-const handleError = () => {
-  isErrorModalOpen.value = false;
-  emit('error');
-};
-
-const handleSuccess = () => {
-  isSuccessModalOpen.value = false;
+  // 캐릭터 선택 완료 시 부모에게 알림
+  isModalOpen.value = false;
+  isSigningUp.value = false;
 
   // 최종 선택된 캐릭터 정보 전달
   const selectedCharacterData = {
@@ -154,7 +113,12 @@ const handleSuccess = () => {
   };
 
   emit('complete', selectedCharacterData);
-
-  router.push('/login');
 };
+
+// 선택된 캐릭터 정보
+const selectedCharacter = computed(() => {
+  return selected.value !== null
+    ? CHOOGOOMI_CHARACTERS.find(char => char.choogoomiId === selected.value)
+    : null;
+});
 </script>

--- a/src/views/signup/components/signup/SignupFormComponent.vue
+++ b/src/views/signup/components/signup/SignupFormComponent.vue
@@ -169,7 +169,7 @@ const member = reactive({
   email: '',
   password: '',
   nickname: '',
-  choogooMi: '',
+  choogooMi: 'A',
 });
 
 //이메일 전송용


### PR DESCRIPTION
# 📌 자산 연동에 필요한 토큰을 위해 연동 전 회원가입 및 로그인 요청으로 수정

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 자산 연동 요청 시 accessToken이 필요해서 연동 이전에 가입 요청 후 로그인을 통해 토큰을 저장하도록 수정했습니다.
- 로그인 API를 authAPI에 분리했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
현재 회원가입 요청 후 로그인을 하여 `자산 연동 페이지 이후부터는 계속 로그인 된 상태`입니다.
이후에 한번 자산 연동을 완전히 로그인 이후에서만 하도록 수정하거나 회원가입 후 자동 로그인 등 방법을 고민해봐야 할 것 같습니다!