### PR TITLE
fix: 하단네비게이션바 설정 추가

### DIFF
--- a/src/components/BottomNavigation.vue
+++ b/src/components/BottomNavigation.vue
@@ -4,19 +4,25 @@
       <router-link
         to="/"
         class="flex flex-col items-center no-underline! text-gray-300! transition-all duration-300 flex-1 px-1 py-2"
-        :class="{ 'text-limegreen-500!': $route.path === '/' }"
+        :class="{
+          'text-limegreen-500!': isActive('home'),
+        }"
       >
         <div class="flex justify-center items-center mb-1">
           <img
             :src="isActive('home') ? homeSelected : homeBasic"
             alt="home"
             class="size-5 transition-transform duration-200 object-contain hover:scale-110"
-            :class="{ 'scale-110': $route.path === '/' }"
+            :class="{
+              'scale-110': isActive('home'),
+            }"
           />
         </div>
         <span
           class="text-[10px] font-spoqa text-center"
-          :class="{ 'font-semibold': $route.path === '/' }"
+          :class="{
+            'font-semibold': isActive('home'),
+          }"
         >
           Home
         </span>
@@ -25,19 +31,19 @@
       <router-link
         to="/ranking"
         class="flex flex-col items-center no-underline! text-gray-300! transition-all duration-300 flex-1 px-1 py-2"
-        :class="{ 'text-limegreen-500!': $route.path === '/ranking' }"
+        :class="{ 'text-limegreen-500!': isActive('ranking') }"
       >
         <div class="flex justify-center items-center mb-1">
           <img
             :src="isActive('ranking') ? rankingSelected : rankingBasic"
             alt="ranking"
             class="size-5 transition-transform duration-200 object-contain hover:scale-110"
-            :class="{ 'scale-110': $route.path === '/ranking' }"
+            :class="{ 'scale-110': isActive('ranking') }"
           />
         </div>
         <span
           class="text-[10px] font-spoqa text-center"
-          :class="{ 'font-semibold': $route.path === '/ranking' }"
+          :class="{ 'font-semibold': isActive('ranking') }"
         >
           Ranking
         </span>
@@ -46,19 +52,19 @@
       <router-link
         to="/matching"
         class="flex flex-col items-center no-underline! text-gray-300! transition-all duration-300 flex-1 px-1 py-2"
-        :class="{ 'text-limegreen-500!': $route.path === '/matching' }"
+        :class="{ 'text-limegreen-500!': isActive('matching') }"
       >
         <div class="flex justify-center items-center mb-1">
           <img
             :src="isActive('matching') ? matchingSelected : matchingBasic"
             alt="matching"
             class="size-5 transition-transform duration-200 object-contain hover:scale-110"
-            :class="{ 'scale-110': $route.path === '/matching' }"
+            :class="{ 'scale-110': isActive('matching') }"
           />
         </div>
         <span
           class="text-[10px] font-spoqa text-center"
-          :class="{ 'font-semibold': $route.path === '/matching' }"
+          :class="{ 'font-semibold': isActive('matching') }"
         >
           Matching
         </span>
@@ -67,19 +73,19 @@
       <router-link
         to="/mypage"
         class="flex flex-col items-center no-underline! text-gray-300! transition-all duration-300 flex-1 px-1 py-2"
-        :class="{ 'text-limegreen-500!': $route.path === '/mypage' }"
+        :class="{ 'text-limegreen-500!': isActive('mypage') }"
       >
         <div class="flex justify-center items-center mb-1">
           <img
             :src="isActive('mypage') ? mypageSelected : mypageBasic"
             alt="mypage"
             class="size-5 transition-transform duration-200 object-contain hover:scale-110"
-            :class="{ 'scale-110': $route.path === '/mypage' }"
+            :class="{ 'scale-110': isActive('mypage') }"
           />
         </div>
         <span
           class="text-[10px] font-spoqa text-center"
-          :class="{ 'font-semibold': $route.path === '/mypage' }"
+          :class="{ 'font-semibold': isActive('mypage') }"
         >
           MyPage
         </span>
@@ -106,12 +112,14 @@ const route = useRoute();
 // 현재 경로가 해당 네비게이션과 일치하는지 확인
 const isActive = navType => {
   const paths = {
-    home: '/',
-    ranking: '/ranking',
-    matching: '/matching',
-    mypage: '/mypage',
+    home: ['/', '/transaction'],
+    ranking: ['/ranking'],
+    matching: ['/matching', '/mission-quiz'],
+    mypage: ['/mypage'],
   };
-  return route.path === paths[navType];
+  return paths[navType].some(path => {
+    return path === '/' ? route.path === '/' : route.path.startsWith(path);
+  });
 };
 </script>
 


### PR DESCRIPTION
## 📝 변경 내용

- 하단 네비게이션 바 탭의 메인 페이지 이외의 페이지들에도 색 바뀌는 설정 적용
---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)

<img width="2298" height="1852" alt="image" src="https://github.com/user-attachments/assets/94106de6-9ed3-4f2b-bf32-1a19738ce6ef" />
- 각 네비게이션 바 탭의 하위페이지가 추가될 때마다 이 부분 ⬇️ 에 추가해주시면 됩니다!
<img width="465" height="186" alt="image" src="https://github.com/user-attachments/assets/83769e0f-84c9-4f8c-a5ea-22b4117a04f1" />


