### PR TITLE
feat: 계좌 연동 및 거래 내역 조회 API 추가

### DIFF
--- a/src/api/bankApi.js
+++ b/src/api/bankApi.js
@@ -1,6 +1,45 @@
 // axios 라이브러리 불러오기 -> 커스텀 인스턴스 만들기
 import axiosInstance from './axios';
 
+// 계좌 연동
+export const fetchBankFromCodef = async ({
+  selectedBankId,
+  userBankId,
+  userBankPassword,
+}) => {
+  try {
+    const response = await axiosInstance.post('/api/codef/account/add', {
+      bankId: selectedBankId,
+      userBankId: userBankId,
+      userBankPassword: userBankPassword,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('은행 목록 불러오기 실패:', error);
+    throw error;
+  }
+};
+
+// 연동된 계좌의 거래 내역 불러오기
+export const fetchTransactionsFromCodef = async ({
+  account,
+  organization,
+  startDate,
+  endDate,
+}) => {
+  try {
+    const response = await axiosInstance.post(`/api/codef/transaction/add`, {
+      account,
+      organization,
+      startDate,
+      endDate,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('거래내역 조회 실패:', error);
+    throw error;
+  }
+};
 // 계좌 목록 조회
 export const fetchAccounts = async () => {
   try {

--- a/src/views/asset/ConnectModal.vue
+++ b/src/views/asset/ConnectModal.vue
@@ -41,7 +41,7 @@
       </div>
       <div class="flex justify-center w-full" v-else>
         <button
-          @click="$emit('close')"
+          @click="handleClose"
           class="w-32 h-12 bg-limegreen-500 text-ivory rounded-[10px] text-[20px]"
         >
           재연동 시도
@@ -52,7 +52,7 @@
 </template>
 
 <script setup>
-const emit = defineEmits(['next', 'additional-connect']);
+const emit = defineEmits(['next', 'additional-connect', 'close']);
 
 defineProps({
   title: { type: String, default: '자산 연동 성공!' },
@@ -67,5 +67,9 @@ const handleConfirm = () => {
 
 const handleAddtionalConnect = () => {
   emit('additional-connect');
+};
+
+const handleClose = () => {
+  emit('close');
 };
 </script>


### PR DESCRIPTION
# 📌 계좌 연동 API 추가

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 계좌 연동 이후 연동된 계좌의 계좌 번호를 통해 거래 내역을 불러오고 DB에 저장하는 API 호출을 추가했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
