### PR TITLE
feat: 첫 로그인 했을 때의 자산 분석 리포트 화면 UI 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "pinia": "^3.0.3",
         "tailwindcss": "^4.1.11",
         "vue": "^3.5.17",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.5.1",
+        "vue3-carousel": "^0.16.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -5428,6 +5429,15 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vue3-carousel": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/vue3-carousel/-/vue3-carousel-0.16.0.tgz",
+      "integrity": "sha512-IKRKtvHP8gNDRHSzINXwFbJ/Zy2HS+Gv2lXPnAEop6pxsvB17+fz2WQlNZ6ytilLkM5DOu/jXPoDQi/xy17bjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.11",
     "vue": "^3.5.17",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vue3-carousel": "^0.16.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,6 +12,7 @@ import MyPageEditInfoView from '@/views/mypage/MyPageEditInfoView.vue';
 import MyPageRecordView from '@/views/mypage/MyPageRecordView.vue';
 import MyPageView from '@/views/mypage/MyPageView.vue';
 import RankingView from '@/views/ranking/RankingView.vue';
+import CharacterSelectComponent from '@/views/signup/components/character/CharacterSelectComponent.vue';
 import SurveyView from '@/views/signup/components/survey/SurveyView.vue';
 import SignupView from '@/views/signup/SignupView.vue';
 
@@ -57,6 +58,11 @@ const router = createRouter({
       path: '/asset/report',
       name: 'assetReport',
       component: AssetReportView,
+    },
+    {
+      path: '/character',
+      name: 'character',
+      component: CharacterSelectComponent,
     },
     {
       path: '/ranking',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 
 import AssetConnectView from '@/views/asset/AssetConnectView.vue';
 import AssetSelectView from '@/views/asset/AssetSelectView.vue';
+import AssetReportView from '@/views/asset/report/AssetReportView.vue';
 import HomeView from '@/views/home/HomeView.vue';
 import TransactionView from '@/views/home/TransactionView.vue';
 import LoginView from '@/views/login/LoginView.vue';
@@ -51,6 +52,11 @@ const router = createRouter({
       path: '/asset/select/:bankId',
       name: 'assetConnect',
       component: AssetConnectView,
+    },
+    {
+      path: '/asset/report',
+      name: 'assetReport',
+      component: AssetReportView,
     },
     {
       path: '/ranking',

--- a/src/views/asset/report/AssetReportView.vue
+++ b/src/views/asset/report/AssetReportView.vue
@@ -1,0 +1,192 @@
+<template>
+  <!-- 전체 배경 -->
+  <div
+    class="min-h-screen bg-ivory flex flex-col relative items-center justify-center px-4 gap-y-6"
+  >
+    <!-- 상단 네비게이션 -->
+    <TopNavigation
+      :show-back="false"
+      :show-logo-text="true"
+      :logo-text="'분석 리포트'"
+    />
+    <!-- 순자산 박스 -->
+    <div class="bg-limegreen-100 rounded-lg w-full flex flex-col gap-y-1 p-6">
+      <span class="text-limegreen-900 text-lg mb-1">
+        '{{ userData.nickname }}' 님의 순자산
+      </span>
+      <span class="text-green text-xl">
+        {{ userData.asset.toLocaleString() }}원
+      </span>
+      <span class="text-gray-300 text-sm">
+        {{ userData.summary }}
+      </span>
+    </div>
+    <!-- 메인 컨테이너 -->
+    <div
+      class="w-full flex h-110 flex-col bg-limegreen-500 rounded-lg p-6 gap-y-4"
+    >
+      <!-- 지출 분석 차트 박스 -->
+      <div class="bg-ivory rounded-lg p-4">
+        <div class="rounded-lg flex flex-col gap-y-1">
+          <span class="text-gray-600 text-[14px]">
+            전체 수입 대비 지출이 많아요!
+          </span>
+
+          <div class="flex items-center justify-between">
+            <!-- 원형 차트 -->
+            <div class="relative w-22 h-22">
+              <svg class="w-22 h-22 transform -rotate-90" viewBox="0 0 120 120">
+                <!-- 배경 원 -->
+                <circle
+                  cx="60"
+                  cy="60"
+                  r="50"
+                  fill="none"
+                  stroke="#e5e7eb"
+                  stroke-width="10"
+                />
+                <!-- 진행률 원 -->
+                <circle
+                  cx="60"
+                  cy="60"
+                  r="50"
+                  fill="none"
+                  stroke="#228b22"
+                  stroke-width="10"
+                  stroke-dasharray="314.16"
+                  :stroke-dashoffset="314.16 - (314.16 * expenseRatio) / 100"
+                  stroke-linecap="round"
+                />
+              </svg>
+              <div class="absolute inset-0 flex items-center justify-center">
+                <span class="text-sm text-green">{{ expenseRatio }}%</span>
+              </div>
+            </div>
+            <!-- 카테고리별 지출 -->
+            <div class="flex flex-col space-y-2">
+              <div
+                v-for="category in expenseCategories"
+                :key="category.name"
+                class="flex items-center justify-between gap-2"
+              >
+                <!-- 카테고리 이름 -->
+                <span class="text-gray-300 text-sm">{{ category.name }}</span>
+                <div class="flex items-center gap-2">
+                  <!-- 지출 퍼센트 바 -->
+                  <div class="w-20 h-2 rounded-full overflow-hidden">
+                    <div
+                      class="h-full bg-green rounded-full"
+                      :style="{ width: `${category.percentage}%` }"
+                    ></div>
+                  </div>
+                  <!-- 퍼센트 표시 -->
+                  <span class="text-[10px] text-gray-300"
+                    >{{ category.percentage }}%</span
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 분석 내용 박스 -->
+      <div class="bg-limegreen-200 rounded-lg overflow-hidden">
+        <div
+          class="bg-ivory rounded-lg p-4 flex flex-col gap-y-1 h-80 overflow-y-scroll"
+        >
+          <div class="text-gray-600">{{ reportData.title }}</div>
+          <div class="text-gray-600 leading-relaxed whitespace-pre-line">
+            {{ reportData.content }}
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- 다음 버튼 -->
+
+    <button
+      class="fixed bottom-10 w-[335px] bg-limegreen-500 text-white text-2xl! py-4 rounded-lg"
+      @click="handleNext"
+    >
+      다음
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+import TopNavigation from '@/components/TopNavigation.vue';
+
+const router = useRouter();
+const userData = ref({
+  nickname: '닉네임',
+  asset: 5000000,
+  summary: '현재 자산은 평균보다 조금 낮아요!',
+});
+// API 응답 데이터 구조
+const reportData = ref({
+  reportId: 1,
+  userId: 101,
+  title: '지출이 너무 많고 카페,식사 등 식비에 지출이 큰 유형이에요.',
+  content: `한달 수입의 80퍼센트 이상을 지출로 쓰고 있습니다.
+그 중 카페에서 매주 10만원 이상을 소비하여 이 부분을 줄인다면
+목표하는 투자형에 필요한 시드머니를 채울 수 있을 것으로 예상됩니다.
+
+현재 지출 패턴을 분석한 결과:
+- 월 카페 지출: 약 40만원
+- 외식비: 약 25만원
+- 기타 식비: 약 15만원
+
+이 중 카페 지출만 절반으로 줄여도 월 20만원, 연간 240만원을 절약할 수 있습니다.
+절약한 금액을 투자 포트폴리오에 투입하면 장기적으로 더 큰 수익을 기대할 수 있습니다.`,
+  regDate: '20250716',
+});
+
+// 차트 데이터
+const expenseRatio = ref(80);
+const expenseCategories = ref([
+  { name: '식비', percentage: 35 },
+  { name: '카페', percentage: 25 },
+  { name: '쇼핑', percentage: 20 },
+  { name: '기타', percentage: 20 },
+]);
+
+// 날짜 포맷팅 함수
+const formatDate = dateString => {
+  if (!dateString) return '';
+  const year = dateString.substring(0, 4);
+  const month = dateString.substring(4, 6);
+  const day = dateString.substring(6, 8);
+  return `${year}년 ${month}월 ${day}일`;
+};
+
+// API에서 리포트 데이터 가져오기
+const fetchReportData = async () => {
+  try {
+    // 실제 API 호출 시 사용할 코드
+    // const response = await fetch('/api/report/{reportId}');
+    // const data = await response.json();
+    // reportData.value = data;
+
+    console.log('리포트 데이터 로드됨:', reportData.value);
+  } catch (error) {
+    console.error('리포트 데이터 로드 실패:', error);
+  }
+};
+
+// 다음 버튼 클릭 핸들러
+const handleNext = () => {
+  console.log('분석 리포트 완료');
+  // router.push('/next-page'); // 필요시 라우팅
+};
+
+onMounted(() => {
+  fetchReportData();
+});
+</script>
+
+<style scoped>
+/* 필요시 추가 스타일 */
+</style>

--- a/src/views/asset/report/AssetReportView.vue
+++ b/src/views/asset/report/AssetReportView.vue
@@ -1,68 +1,73 @@
 <template>
   <!-- 전체 배경 -->
   <div
-    class="min-h-screen bg-ivory flex flex-col relative items-center justify-center px-4 gap-y-6"
+    class="min-h-screen bg-ivory flex flex-col items-center justify-between px-4"
   >
-    <!-- 상단 네비게이션 -->
-    <TopNavigation
-      :show-back="false"
-      :show-logo-text="true"
-      :logo-text="'분석 리포트'"
-    />
-    <!-- 순자산 박스 -->
-    <div class="bg-limegreen-100 rounded-lg w-full flex flex-col gap-y-1 p-6">
-      <span class="text-limegreen-900 text-lg mb-1">
-        '{{ userData.nickname }}' 님의 순자산
-      </span>
-      <span class="text-green text-xl">
-        {{ userData.asset.toLocaleString() }}원
-      </span>
-      <span class="text-gray-300 text-sm">
-        {{ userData.summary }}
-      </span>
+    <!-- 헤더 -->
+    <div class="text-black text-3xl h-20 flex items-center">
+      자산 분석 리포트
     </div>
-    <!-- 메인 컨테이너 -->
-    <div
-      class="w-full flex h-110 flex-col bg-limegreen-500 rounded-lg p-6 gap-y-4"
-    >
-      <Carousel v-bind="carouselConfig">
-        <Slide>
-          <!-- 지출 분석 차트 박스 -->
-          <AnalysisCard
-            mode="chart"
-            title="전체 수입 대비 지출이 많아요!"
-            :chart-data="chartAnalysisData"
-          />
-        </Slide>
-        <!-- 캐릭터 분석 예제 -->
-        <Slide>
-          <AnalysisCard
-            mode="character"
-            :character-data="characterAnalysisData"
-          />
-        </Slide>
-      </Carousel>
 
-      <!-- 분석 내용 박스 -->
-      <div class="bg-limegreen-200 rounded-lg overflow-hidden">
-        <div
-          class="bg-ivory rounded-lg p-4 flex flex-col gap-y-1 h-80 overflow-y-scroll [&::-webkit-scrollbar]:hidden"
-        >
-          <div class="text-gray-600">{{ reportData.title }}</div>
-          <div class="text-gray-600 leading-relaxed whitespace-pre-line">
-            {{ reportData.content }}
+    <!-- 메인 콘텐츠 영역 -->
+    <div class="w-full flex flex-col gap-y-6 pb-6">
+      <!-- 순자산 박스 -->
+      <div class="bg-limegreen-100 rounded-lg w-full flex flex-col gap-y-1 p-6">
+        <span class="text-limegreen-900 text-lg mb-1">
+          '{{ userData.nickname }}' 님의 순자산
+        </span>
+        <span class="text-green text-xl">
+          {{ userData.asset.toLocaleString() }}원
+        </span>
+        <span class="text-gray-300 text-sm">
+          {{ userData.summary }}
+        </span>
+      </div>
+
+      <!-- 메인 컨테이너 -->
+      <div
+        class="w-full flex h-110 flex-col bg-limegreen-500 rounded-lg p-6 gap-y-4"
+      >
+        <Carousel v-bind="carouselConfig">
+          <Slide>
+            <!-- 지출 분석 차트 박스 -->
+            <AnalysisCard
+              mode="chart"
+              title="전체 수입 대비 지출이 많아요!"
+              :chart-data="chartAnalysisData"
+            />
+          </Slide>
+          <!-- 캐릭터 분석 예제 -->
+          <Slide>
+            <AnalysisCard
+              mode="character"
+              :character-data="characterAnalysisData"
+            />
+          </Slide>
+        </Carousel>
+
+        <!-- 분석 내용 박스 -->
+        <div class="bg-limegreen-200 rounded-lg overflow-hidden">
+          <div
+            class="bg-ivory rounded-lg p-4 flex flex-col gap-y-1 h-80 overflow-y-scroll [&::-webkit-scrollbar]:hidden"
+          >
+            <div class="text-gray-600">{{ reportData.title }}</div>
+            <div class="text-gray-600 leading-relaxed whitespace-pre-line">
+              {{ reportData.content }}
+            </div>
           </div>
         </div>
       </div>
     </div>
-    <!-- 다음 버튼 -->
 
-    <button
-      class="fixed bottom-10 w-[335px] bg-limegreen-500 text-white text-2xl! py-4 rounded-lg"
-      @click="handleNext"
-    >
-      다음
-    </button>
+    <!-- 다음 버튼 -->
+    <div class="w-full pb-6">
+      <button
+        class="w-full bg-limegreen-500 text-white text-2xl py-4 rounded-lg"
+        @click="handleNext"
+      >
+        다음
+      </button>
+    </div>
   </div>
 </template>
 
@@ -72,7 +77,6 @@ import { Carousel, Slide } from 'vue3-carousel';
 import 'vue3-carousel/carousel.css';
 import { useRouter } from 'vue-router';
 
-import TopNavigation from '@/components/TopNavigation.vue';
 import AnalysisCard from '@/views/asset/report/components/AnalysisCard.vue';
 
 const carouselConfig = {

--- a/src/views/asset/report/AssetReportView.vue
+++ b/src/views/asset/report/AssetReportView.vue
@@ -25,70 +25,23 @@
     <div
       class="w-full flex h-110 flex-col bg-limegreen-500 rounded-lg p-6 gap-y-4"
     >
-      <!-- 지출 분석 차트 박스 -->
-      <div class="bg-ivory rounded-lg p-4">
-        <div class="rounded-lg flex flex-col gap-y-1">
-          <span class="text-gray-600 text-[14px]">
-            전체 수입 대비 지출이 많아요!
-          </span>
-
-          <div class="flex items-center justify-between">
-            <!-- 원형 차트 -->
-            <div class="relative w-22 h-22">
-              <svg class="w-22 h-22 transform -rotate-90" viewBox="0 0 120 120">
-                <!-- 배경 원 -->
-                <circle
-                  cx="60"
-                  cy="60"
-                  r="50"
-                  fill="none"
-                  stroke="#e5e7eb"
-                  stroke-width="10"
-                />
-                <!-- 진행률 원 -->
-                <circle
-                  cx="60"
-                  cy="60"
-                  r="50"
-                  fill="none"
-                  stroke="#228b22"
-                  stroke-width="10"
-                  stroke-dasharray="314.16"
-                  :stroke-dashoffset="314.16 - (314.16 * expenseRatio) / 100"
-                  stroke-linecap="round"
-                />
-              </svg>
-              <div class="absolute inset-0 flex items-center justify-center">
-                <span class="text-sm text-green">{{ expenseRatio }}%</span>
-              </div>
-            </div>
-            <!-- 카테고리별 지출 -->
-            <div class="flex flex-col space-y-2">
-              <div
-                v-for="category in expenseCategories"
-                :key="category.name"
-                class="flex items-center justify-between gap-2"
-              >
-                <!-- 카테고리 이름 -->
-                <span class="text-gray-300 text-sm">{{ category.name }}</span>
-                <div class="flex items-center gap-2">
-                  <!-- 지출 퍼센트 바 -->
-                  <div class="w-20 h-2 rounded-full overflow-hidden">
-                    <div
-                      class="h-full bg-green rounded-full"
-                      :style="{ width: `${category.percentage}%` }"
-                    ></div>
-                  </div>
-                  <!-- 퍼센트 표시 -->
-                  <span class="text-[10px] text-gray-300"
-                    >{{ category.percentage }}%</span
-                  >
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Carousel v-bind="carouselConfig">
+        <Slide>
+          <!-- 지출 분석 차트 박스 -->
+          <AnalysisCard
+            mode="chart"
+            title="전체 수입 대비 지출이 많아요!"
+            :chart-data="chartAnalysisData"
+          />
+        </Slide>
+        <!-- 캐릭터 분석 예제 -->
+        <Slide>
+          <AnalysisCard
+            mode="character"
+            :character-data="characterAnalysisData"
+          />
+        </Slide>
+      </Carousel>
 
       <!-- 분석 내용 박스 -->
       <div class="bg-limegreen-200 rounded-lg overflow-hidden">
@@ -114,10 +67,20 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
+import { Carousel, Navigation, Pagination, Slide } from 'vue3-carousel';
+import 'vue3-carousel/carousel.css';
 import { useRouter } from 'vue-router';
 
 import TopNavigation from '@/components/TopNavigation.vue';
+import AnalysisCard from '@/views/asset/report/components/AnalysisCard.vue';
+
+const carouselConfig = {
+  itemsToShow: 1,
+  wrapAround: true,
+  autoplay: 3000,
+  slideEffect: 'fade',
+};
 
 const router = useRouter();
 const userData = ref({
@@ -153,14 +116,18 @@ const expenseCategories = ref([
   { name: '기타', percentage: 20 },
 ]);
 
-// 날짜 포맷팅 함수
-const formatDate = dateString => {
-  if (!dateString) return '';
-  const year = dateString.substring(0, 4);
-  const month = dateString.substring(4, 6);
-  const day = dateString.substring(6, 8);
-  return `${year}년 ${month}월 ${day}일`;
-};
+// AnalysisCard에서 사용할 차트 데이터
+const chartAnalysisData = computed(() => ({
+  percentage: expenseRatio.value,
+  categories: expenseCategories.value,
+}));
+
+// AnalysisCard에서 사용할 캐릭터 데이터
+const characterAnalysisData = computed(() => ({
+  image: '/src/assets/img/characters/A.png',
+  name: '지출제로형',
+  summary: '작은 실천이 모여 내일을 만든다!',
+}));
 
 // API에서 리포트 데이터 가져오기
 const fetchReportData = async () => {

--- a/src/views/asset/report/AssetReportView.vue
+++ b/src/views/asset/report/AssetReportView.vue
@@ -46,7 +46,7 @@
       <!-- 분석 내용 박스 -->
       <div class="bg-limegreen-200 rounded-lg overflow-hidden">
         <div
-          class="bg-ivory rounded-lg p-4 flex flex-col gap-y-1 h-80 overflow-y-scroll"
+          class="bg-ivory rounded-lg p-4 flex flex-col gap-y-1 h-80 overflow-y-scroll [&::-webkit-scrollbar]:hidden"
         >
           <div class="text-gray-600">{{ reportData.title }}</div>
           <div class="text-gray-600 leading-relaxed whitespace-pre-line">
@@ -68,7 +68,7 @@
 
 <script setup>
 import { computed, onMounted, ref } from 'vue';
-import { Carousel, Navigation, Pagination, Slide } from 'vue3-carousel';
+import { Carousel, Slide } from 'vue3-carousel';
 import 'vue3-carousel/carousel.css';
 import { useRouter } from 'vue-router';
 

--- a/src/views/asset/report/AssetReportView.vue
+++ b/src/views/asset/report/AssetReportView.vue
@@ -76,10 +76,22 @@ import TopNavigation from '@/components/TopNavigation.vue';
 import AnalysisCard from '@/views/asset/report/components/AnalysisCard.vue';
 
 const carouselConfig = {
+  // 한 번에 보여줄 슬라이드 개수 (1개씩 보여주기)
   itemsToShow: 1,
+  // 마지막 슬라이드에서 첫 번째 슬라이드로 순환 이동 가능
   wrapAround: true,
-  autoplay: 3000,
-  slideEffect: 'fade',
+  // 자동재생 간격 (밀리초) - 2초마다 자동으로 다음 슬라이드
+  autoplay: 2000,
+  // 슬라이드 전환 애니메이션 속도 (밀리초) - 2초 동안 부드럽게 전환
+  transition: 2000,
+  // 슬라이드 간 간격 (픽셀) - 슬라이드 사이 20px 여백
+  gap: 20,
+  // 마우스 드래그로 슬라이드 이동 허용
+  mouseDrag: true,
+  // 터치(모바일)로 슬라이드 이동 허용
+  touchDrag: true,
+  // 마우스 호버 시 자동재생 일시정지 (사용자가 내용을 자세히 볼 수 있도록)
+  pauseAutoplayOnHover: true,
 };
 
 const router = useRouter();
@@ -145,8 +157,7 @@ const fetchReportData = async () => {
 
 // 다음 버튼 클릭 핸들러
 const handleNext = () => {
-  console.log('분석 리포트 완료');
-  // router.push('/next-page'); // 필요시 라우팅
+  router.push('/character');
 };
 
 onMounted(() => {

--- a/src/views/asset/report/components/AnalysisCard.vue
+++ b/src/views/asset/report/components/AnalysisCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-ivory rounded-lg p-4">
+  <div class="bg-ivory rounded-lg p-6 w-full h-full">
     <div class="rounded-lg flex flex-col gap-y-1">
       <!-- 제목 -->
       <span class="text-gray-600 text-[14px]">

--- a/src/views/asset/report/components/AnalysisCard.vue
+++ b/src/views/asset/report/components/AnalysisCard.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="bg-ivory rounded-lg p-4">
+    <div class="rounded-lg flex flex-col gap-y-1">
+      <!-- 제목 -->
+      <span class="text-gray-600 text-[14px]">
+        {{ title }}
+      </span>
+
+      <!-- 차트 모드 -->
+      <div v-if="mode === 'chart'" class="flex items-center justify-between">
+        <!-- 원형 차트 -->
+        <div class="relative w-22 h-22">
+          <svg class="w-22 h-22 transform -rotate-90" viewBox="0 0 120 120">
+            <!-- 배경 원 -->
+            <circle
+              cx="60"
+              cy="60"
+              r="50"
+              fill="none"
+              stroke="#e5e7eb"
+              stroke-width="10"
+            />
+            <!-- 진행률 원 -->
+            <circle
+              cx="60"
+              cy="60"
+              r="50"
+              fill="none"
+              stroke="#228b22"
+              stroke-width="10"
+              stroke-dasharray="314.16"
+              :stroke-dashoffset="
+                314.16 - (314.16 * chartData.percentage) / 100
+              "
+              stroke-linecap="round"
+            />
+          </svg>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <span class="text-sm text-green">{{ chartData.percentage }}%</span>
+          </div>
+        </div>
+
+        <!-- 카테고리별 데이터 -->
+        <div class="flex flex-col space-y-2">
+          <div
+            v-for="category in chartData.categories"
+            :key="category.name"
+            class="flex items-center justify-between gap-2"
+          >
+            <!-- 카테고리 이름 -->
+            <span class="text-gray-300 text-sm">{{ category.name }}</span>
+            <div class="flex items-center gap-2">
+              <!-- 진행률 바 -->
+              <div class="w-20 h-2 rounded-full overflow-hidden">
+                <div
+                  class="h-full bg-green rounded-full"
+                  :style="{ width: `${category.percentage}%` }"
+                ></div>
+              </div>
+              <!-- 퍼센트 표시 -->
+              <span class="text-[10px] text-gray-300">
+                {{ category.percentage }}%
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 캐릭터 모드 -->
+      <div
+        v-else-if="mode === 'character'"
+        class="flex items-center justify-between"
+      >
+        <!-- 캐릭터 이미지 -->
+        <div class="flex items-center justify-center flex-col">
+          <img
+            :src="characterData.image"
+            :alt="characterData.name"
+            class="size-22 object-cover"
+          />
+          <div class="text-limegreen-700">
+            {{ characterData.name }}
+          </div>
+        </div>
+
+        <!-- 캐릭터 정보 -->
+        <div class="flex-1">
+          <div class="text-gray-500 text-sm leading-relaxed">
+            {{ characterData.summary }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+
+// Props 정의
+const props = defineProps({
+  // 모드: 'chart', 'character'
+  mode: {
+    type: String,
+    default: 'chart',
+    validator: value => ['chart', 'character'].includes(value),
+  },
+  // 카드 제목
+  title: {
+    type: String,
+    default: '',
+  },
+  // 차트 모드 데이터
+  chartData: {
+    type: Object,
+    default: () => ({
+      percentage: 0,
+      categories: [],
+    }),
+  },
+  // 캐릭터 모드 데이터
+  characterData: {
+    type: Object,
+    default: () => ({
+      image: '',
+      name: '',
+      summary: '',
+    }),
+  },
+});
+</script>
+
+<style scoped>
+/* 필요시 추가 스타일 */
+</style>


### PR DESCRIPTION
# 📌 회원가입 후 첫 로그인 시의 자산 연동 후 분석 리포트 화면 UI 작업

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 마이페이지에서 분석 리포트 보기가 아닌 첫 로그인 시의 리포트 화면 UI를 구현했습니다.
- 분석 차트와 유형 추천을 캐러셀 라이브러리를 사용하여 구현했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 캐러셀 효과가 정상적으로 작동하는지 확인했습니다. 

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

<img width="394" height="960" alt="스크린샷 2025-07-29 오후 2 31 29" src="https://github.com/user-attachments/assets/76b91f0d-5dc8-49fd-8706-9dc6bbd7dd03" />

https://github.com/user-attachments/assets/7c47efa2-e772-4dc9-97de-b2c6b04e2149

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->

`vue3-carousel` 패키지를 설치했기 때문에 풀 받으신 후에 패키지 설치(`npm install`)를 꼭 해주세요!!
**node 버전은 처음에 통일했던 22.14.0 입니다!**
지금은 자동으로 넘겨지는 값을 2초로 임의로 지정해놨는데 괜찮을까요?

분석 리포트 api가 완성되면 마이페이지에서의 분석 리포트 보기 페이지에 맞게 추가 작업을 진행하겠습니다!