### PR TITLE
feat : [매칭 페이지] 매칭 결과 모달창 ui 구현

### DIFF
--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -180,12 +180,13 @@
       @close="modalClose"
       @confirm="goToQuiz"
     />
+    <MatchingResultModal v-if="showResultModal" @close="closeResultModal" />
     <BottomNavigation />
   </div>
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import img_character_user1 from '@/assets/img/characters/character_zero_1.png';
@@ -194,10 +195,13 @@ import icon_info from '@/assets/img/icons/feature/icon_info.png';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 
+import MatchingResultModal from './components/MatchingResultModal.vue';
 import QuizAlertModal from './components/QuizAlertModal.vue';
 
 const router = useRouter();
 const showModal = ref(false);
+
+const showResultModal = ref(false);
 
 const MATCHING_DATA = ref({
   matchingId: 123,
@@ -326,6 +330,10 @@ const MISSION_INFORMATION = [
   },
 ];
 
+const closeResultModal = () => {
+  showResultModal.value = false;
+};
+
 const goToWrite = () => {
   router.push({ name: 'missionWrite' });
 };
@@ -342,4 +350,8 @@ const goToQuiz = () => {
   console.log('클릭됨');
   router.push({ name: 'missionQuiz' });
 };
+
+onMounted(() => {
+  showResultModal.value = true;
+});
 </script>

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -201,7 +201,7 @@ import QuizAlertModal from './components/QuizAlertModal.vue';
 const router = useRouter();
 const showModal = ref(false);
 
-const showResultModal = ref(false);
+const showResultModal = ref(true);
 
 const MATCHING_DATA = ref({
   matchingId: 123,
@@ -350,8 +350,4 @@ const goToQuiz = () => {
   console.log('클릭됨');
   router.push({ name: 'missionQuiz' });
 };
-
-onMounted(() => {
-  showResultModal.value = true;
-});
 </script>

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -1,29 +1,35 @@
 <template>
   <div class="fixed inset-0 flex items-center justify-center bg-black/70 z-20">
     <div
-      class="flex flex-col gap-3 bg-limegreen-500 rounded-4xl p-6 items-center"
+      class="flex flex-col gap-4 bg-limegreen-500 rounded-4xl p-5 items-center"
     >
       <!--지난주 매칭 결과-->
-      <div>
-        <div class="text-limegreen-900">지난주 매칭 결과</div>
-        <div class="bg-ivory flex rounded-[10px] p-5">
-          <div class="flex gap-5 text-sm text-center">
+      <div class="flex flex-col gap-0.5 w-full mt-1">
+        <div class="text-limegreen-900 text-lg">지난주 매칭 결과</div>
+        <div class="bg-ivory flex rounded-2xl p-5">
+          <div class="flex gap-6 text-sm text-center items-center">
             <div>
-              <div>카카오대학교라이언</div>
-              <div>50점</div>
+              <div class="text-limegreen-900">카카오대학교라이언</div>
+              <div class="text-green">50점</div>
             </div>
-            <div>VS</div>
+            <div class="text-limegreen-900 text-lg">VS</div>
             <div>
-              <div>카카오대학교어피치</div>
-              <div>20점</div>
+              <div class="text-limegreen-900">카카오대학교어피치</div>
+              <div class="text-green">20점</div>
             </div>
           </div>
         </div>
       </div>
       <!--미션 목록-->
-      <div></div>
+      <div class="flex flex-col w-full gap-0.5">
+        <div class="text-limegreen-900 text-lg">미션 목록</div>
+        <div class="flex flex-col gap-2 text-sm">
+          <MissionListCard />
+          <MissionListCard />
+        </div>
+      </div>
       <button
-        class="bg-ivory w-36 h-12 rounded-[10px] text-limegreen-900"
+        class="bg-ivory w-36 h-12 rounded-2xl text-limegreen-900"
         @click="$emit('close')"
       >
         확인
@@ -34,4 +40,6 @@
 
 <script setup>
 import { ref } from 'vue';
+
+import MissionListCard from './MissionListCard.vue';
 </script>

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="fixed inset-0 flex items-center justify-center bg-black/70 z-20">
+    <div
+      class="flex flex-col gap-3 bg-limegreen-500 rounded-4xl p-6 items-center"
+    >
+      <!--지난주 매칭 결과-->
+      <div>
+        <div class="text-limegreen-900">지난주 매칭 결과</div>
+        <div class="bg-ivory flex rounded-[10px] p-5">
+          <div class="flex gap-5 text-sm text-center">
+            <div>
+              <div>카카오대학교라이언</div>
+              <div>50점</div>
+            </div>
+            <div>VS</div>
+            <div>
+              <div>카카오대학교어피치</div>
+              <div>20점</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!--미션 목록-->
+      <div></div>
+      <button
+        class="bg-ivory w-36 h-12 rounded-[10px] text-limegreen-900"
+        @click="$emit('close')"
+      >
+        확인
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+</script>

--- a/src/views/matching/components/MissionListCard.vue
+++ b/src/views/matching/components/MissionListCard.vue
@@ -1,0 +1,4 @@
+<template>
+  <div class="bg-ivory p-3 rounded-xl"></div>
+</template>
+<script></script>

--- a/src/views/matching/components/MissionListCard.vue
+++ b/src/views/matching/components/MissionListCard.vue
@@ -1,4 +1,26 @@
 <template>
-  <div class="bg-ivory p-3 rounded-xl"></div>
+  <div class="bg-ivory p-4 rounded-2xl">
+    <!--닉네임-->
+    <span class="bg-limegreen-100 text-green px-2 py-1 rounded-full text-sm">
+      카카오대학교라이언
+    </span>
+    <!--미션목록-->
+    <div class="flex flex-col mt-2 gap-2">
+      <!--미션 하나-->
+      <div
+        class="flex justify-between bg-limegreen-100 p-1.5 rounded-[10px] items-center"
+      >
+        <div class="flex gap-2">
+          <div
+            class="bg-limegreen-500 rounded-lg w-5 h-5 justify-center text-center"
+          >
+            1
+          </div>
+          <div class="text-sm text-green">공통 미션 : 지출 반성문 쓰기</div>
+        </div>
+        <div class="text-xs text-yellow mr-1">10점</div>
+      </div>
+    </div>
+  </div>
 </template>
 <script></script>


### PR DESCRIPTION
# 📌 매칭 결과 모달창 UI

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 매칭 페이지에 들어갔을 때 지난주 매칭 결과 모달창이 뜨도록 구현
- 확인 버튼 클릭시 모달창 닫히도록 구현
- 미션 목록 카드를 컴포넌트로 분리

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 매칭 페이지에 접속했을 때 매칭 결과 모달창이 뜨는지 확인했습니다.

---

## 📷 스크린샷(선택)
<img width="243" height="436" alt="localhost_5173_matching(노트북)" src="https://github.com/user-attachments/assets/176348da-dedb-42e8-9065-a81103878b91" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
아직 매칭 기록에 대한 api 명세서가 확정되지 않아 대략적인 틀만 작성했습니다.
추후에 명세서에 맞게 구조 수정이 필요할 것 같습니다...
지금은 모달창을 확인하기 위해서 페이지에 접속할 때마다 뜨도록 했는데, 모달창이 완성되면 날짜 설정도 필요할 것 같습니다!
