### PR TITLE
feat: 로그인 라우터 가드 적용 및 피니아 상태 관리

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <div
       class="bg-ivory flex min-h-screen w-[390px] justify-center rounded-[10px] shadow-lg"
     >
-      <LoadingScreen v-if="showSplash" @loading-complete="onLoadingComplete" />
+      <LoadingScreen v-if="showSplash" @loading-complete="true" />
       <!-- 메인 콘텐츠 영역에 상단 패딩 추가 -->
       <div v-else class="w-full">
         <router-view />
@@ -16,18 +16,21 @@
 import { onMounted, ref } from 'vue';
 
 import LoadingScreen from './components/LoadingScreen.vue';
+import { useAuthStore } from './stores/authStore';
 
-const showSplash = ref(true);
+const authStore = useAuthStore();
+const showSplash = ref(false);
 
 onMounted(() => {
-  setTimeout(() => {
-    showSplash.value = false;
-  }, 5000);
+  authStore.initializeAuth();
+  // setTimeout(() => {
+  //   showSplash.value = false;
+  // }, 5000);
 });
 
-const onLoadingComplete = () => {
-  setTimeout(() => {
-    showSplash.value = false;
-  }, 100);
-};
+// const onLoadingComplete = () => {
+//   setTimeout(() => {
+//     showSplash.value = false;
+//   }, 100);
+// };
 </script>

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -51,4 +51,17 @@ const signup = async signupData => {
   }
 };
 
-export default { checkName, sendCode, verifyCode, signup };
+// 로그인
+const login = async (email, password) => {
+  try {
+    const { data } = await axiosInstance.post('api/users/login', {
+      email,
+      password,
+    });
+    return data;
+  } catch {
+    throw new Error('로그인 실패');
+  }
+};
+
+export default { checkName, sendCode, verifyCode, signup, login };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 
+import { useAuthStore } from '@/stores/authStore';
 import AssetConnectView from '@/views/asset/AssetConnectView.vue';
 import AssetSelectView from '@/views/asset/AssetSelectView.vue';
 import AssetReportView from '@/views/asset/report/AssetReportView.vue';
@@ -103,32 +104,46 @@ const router = createRouter({
   ],
 });
 
-// 라우터 가드
-// router.beforeEach((to, from, next) => {
-//   const accessToken = localStorage.getItem('accessToken');
-//   const publicPages = [
-//     '/login',
-//     '/signup',
-//     '/survey1',
-//     '/survey2',
-//     '/character-select',
-//   ];
-//   const assetPages = ['/asset/select', '/asset/connect'];
-//   const authRequired =
-//     !publicPages.includes(to.path) && !assetPages.includes(to.path);
+// ✅ 요청하신 테스트 시나리오에 맞는 라우터 가드
+router.beforeEach(async (to, from, next) => {
+  // ✅ AuthStore에서 로그인 상태 확인
+  const authStore = useAuthStore();
+  const isLoggedIn = authStore.isLoggedIn;
 
-//   if (accessToken) {
-//     // 로그인 후: publicPages (asset 페이지 제외)에 접근 못하도록
-//     if (publicPages.includes(to.path)) {
-//       return next('/');
-//     }
-//   } else {
-//     // 로그인 전: 인증이 필요한 페이지에 접근하면 로그인 페이지로 이동
-//     if (authRequired) {
-//       return next('/login');
-//     }
-//   }
-//   next();
-// });
+  // 공개 페이지 정의
+  const publicPages = ['/login', '/signup', '/survey', '/character'];
 
+  console.log('🚦 Router Guard:', {
+    to: to.path,
+    isLoggedIn,
+  });
+
+  if (isLoggedIn) {
+    // ✅ 로그인된 상태에서의 처리
+    if (publicPages.includes(to.path)) {
+      // ✅ /login → / 리디렉트
+      // ✅ /signup → / 리디렉트
+      console.log('로그인된 사용자가 공개 페이지 접근 → 홈으로 리디렉트');
+      return next('/');
+    }
+
+    // ✅ / → 접근 허용
+    // ✅ /mypage → 접근 허용
+    console.log('로그인된 사용자 → 접근 허용');
+    return next();
+  } else {
+    // ✅ 로그인되지 않은 상태에서의 처리
+    if (publicPages.includes(to.path)) {
+      // ✅ /login → 접근 허용
+      // ✅ /signup → 접근 허용
+      console.log('미로그인 사용자 → 공개 페이지 접근 허용');
+      return next();
+    }
+
+    // ✅ / → /login으로 리디렉트
+    // ✅ /mypage → /login으로 리디렉트
+    console.log('미로그인 사용자가 보호된 페이지 접근 → 로그인으로 리디렉트');
+    return next('/login');
+  }
+});
 export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -111,7 +111,7 @@ router.beforeEach(async (to, from, next) => {
   const isLoggedIn = authStore.isLoggedIn;
 
   // 공개 페이지 정의
-  const publicPages = ['/login', '/signup', '/survey', '/character'];
+  const publicPages = ['/login', '/signup'];
 
   console.log('🚦 Router Guard:', {
     to: to.path,

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -8,31 +8,77 @@ export const useAuthStore = defineStore('auth', {
     accessToken: null,
     refreshToken: null,
   }),
+
+  // Getters (computed properties)
+  getters: {
+    // ✅ 토큰 존재 여부로 로그인 상태 판별
+    isLoggedIn: state => !!state.accessToken,
+  },
+
   // 저장소 액션 정의
   actions: {
+    // ✅ localStorage에서 토큰 복원 (앱 시작 시 호출)
+    initializeAuth() {
+      try {
+        const storedAccessToken = localStorage.getItem('accessToken');
+        const storedRefreshToken = localStorage.getItem('refreshToken');
+
+        if (storedAccessToken) {
+          this.accessToken = storedAccessToken;
+          console.log('✅ AccessToken을 localStorage에서 Pinia로 복원');
+        }
+
+        if (storedRefreshToken) {
+          this.refreshToken = storedRefreshToken;
+          console.log('✅ RefreshToken을 localStorage에서 Pinia로 복원');
+        }
+      } catch (error) {
+        console.error('토큰 복원 중 오류:', error);
+        this.clearAuth();
+      }
+    },
+
     // 액세스 토큰 설정
     setAccessToken(token) {
       this.accessToken = token;
+      // ✅ Pinia와 localStorage 동시 저장
+      localStorage.setItem('accessToken', token);
     },
+
     // 리프레시 토큰 설정
     setRefreshToken(token) {
       this.refreshToken = token;
+      // ✅ Pinia와 localStorage 동시 저장
+      localStorage.setItem('refreshToken', token);
     },
-    // 인증 정보 초기화
+    // ✅ 인증 정보 완전 초기화 (로그아웃 시)
     clearAuth() {
       this.accessToken = null;
       this.refreshToken = null;
+
+      // ✅ localStorage에서도 제거
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+
+      console.log('✅ 인증 정보 초기화 완료');
     },
-    // 로그인
+
+    // ✅ 로그인 액션
     async login(email, password) {
       try {
         const response = await authApi.login(email, password);
 
+        // ✅ 토큰 저장 (Pinia + localStorage)
         this.setAccessToken(response.accessToken);
         this.setRefreshToken(response.refreshToken);
-        return true;
-      } catch {
-        return false;
+
+        console.log('✅ 로그인 성공 - 토큰 저장 완료');
+        return { success: true };
+      } catch (error) {
+        console.error('로그인 실패:', error);
+        return { success: false, error: error.message };
+      } finally {
+        this.isLoading = false;
       }
     },
   },

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+
+export const useAuthStore = defineStore('auth', {
+  // 저장소 상태 정의
+  state: () => ({
+    accessToken: null,
+    refreshToken: null,
+  }),
+  // 저장소 액션 정의
+  actions: {
+    // 액세스 토큰 설정
+    setAccessToken(token) {
+      this.accessToken = token;
+    },
+    // 리프레시 토큰 설정
+    setRefreshToken(token) {
+      this.refreshToken = token;
+    },
+    // 인증 정보 초기화
+    clearAuth() {
+      this.accessToken = null;
+      this.refreshToken = null;
+    },
+  },
+});

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia';
 
+import authApi from '@/api/authApi';
+
 export const useAuthStore = defineStore('auth', {
   // 저장소 상태 정의
   state: () => ({
@@ -20,6 +22,18 @@ export const useAuthStore = defineStore('auth', {
     clearAuth() {
       this.accessToken = null;
       this.refreshToken = null;
+    },
+    // 로그인
+    async login(email, password) {
+      try {
+        const response = await authApi.login(email, password);
+
+        this.setAccessToken(response.accessToken);
+        this.setRefreshToken(response.refreshToken);
+        return true;
+      } catch {
+        return false;
+      }
     },
   },
 });

--- a/src/utils/authGard.js
+++ b/src/utils/authGard.js
@@ -1,4 +1,3 @@
-import authApi from '@/api/authApi';
 import { useAuthStore } from '@/stores/authStore';
 
 // 로그인 상태 확인
@@ -9,11 +8,5 @@ export const isLoggedIn = async () => {
     return false;
   }
   // 토큰이 있으면 로그인 상태
-  try {
-    await authApi.fetchMyInfo();
-    // 로그인 상태
-    return true;
-  } catch {
-    return false;
-  }
+  return true;
 };

--- a/src/utils/authGard.js
+++ b/src/utils/authGard.js
@@ -1,0 +1,19 @@
+import authApi from '@/api/authApi';
+import { useAuthStore } from '@/stores/authStore';
+
+// 로그인 상태 확인
+export const isLoggedIn = async () => {
+  const authStore = useAuthStore();
+  // 토큰이 없으면 로그인 상태가 아님
+  if (!authStore.accessToken) {
+    return false;
+  }
+  // 토큰이 있으면 로그인 상태
+  try {
+    await authApi.fetchMyInfo();
+    // 로그인 상태
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src/views/login/LoginView.vue
+++ b/src/views/login/LoginView.vue
@@ -175,19 +175,16 @@ const handleLogin = async () => {
     return;
   }
   try {
-    const response = await axiosInstance.post('/api/users/login', {
-      email: email.value,
-      password: password.value,
-    });
-    // accessToken, refreshToken 저장
-    window.localStorage.setItem('accessToken', response.data.accessToken);
-    window.localStorage.setItem('refreshToken', response.data.refreshToken);
-
-    authStore.setAccessToken(response.data.accessToken);
-    authStore.setRefreshToken(response.data.refreshToken);
+    // response 값이 true 면 로그인 성공, false 면 로그인 실패
+    const response = await authStore.login(email.value, password.value);
     // 로그인 성공 시 모달 창 띄우기
-    showModal.value = true;
-    modalType.value = 'success';
+    if (response) {
+      showModal.value = true;
+      modalType.value = 'success';
+    } else {
+      showModal.value = true;
+      modalType.value = 'fail';
+    }
   } catch (error) {
     showModal.value = true;
     modalType.value = 'fail';

--- a/src/views/login/LoginView.vue
+++ b/src/views/login/LoginView.vue
@@ -150,8 +150,10 @@ import { useRouter } from 'vue-router';
 
 import axiosInstance from '@/api/axios';
 import AlertModal from '@/components/AlertModal.vue';
+import { useAuthStore } from '@/stores/authStore';
 
 const router = useRouter();
+const authStore = useAuthStore();
 
 const email = ref('');
 const password = ref('');
@@ -180,6 +182,9 @@ const handleLogin = async () => {
     // accessToken, refreshToken 저장
     window.localStorage.setItem('accessToken', response.data.accessToken);
     window.localStorage.setItem('refreshToken', response.data.refreshToken);
+
+    authStore.setAccessToken(response.data.accessToken);
+    authStore.setRefreshToken(response.data.refreshToken);
     // 로그인 성공 시 모달 창 띄우기
     showModal.value = true;
     modalType.value = 'success';
@@ -191,9 +196,8 @@ const handleLogin = async () => {
 
 const handleModalClose = () => {
   showModal.value = false;
-  const token = window.localStorage.getItem('accessToken');
   // 토큰이 있으면 메인 페이지로 이동
-  if (token) {
+  if (authStore.accessToken) {
     router.push('/');
   } else {
     // 토큰이 없으면 로그인 페이지로 이동


### PR DESCRIPTION
# 📌 로그인에 필요한 토큰 전역 상태 관리

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 로딩 화면 5초가 테스트하는 데 답답해서 임시로 안 뜨도록 주석 처리했습니다.
- 로그인 api를 authApi에 분리했습니다.
- 로그인 성공하면 받는 토큰을 localStorage에서 추가로 pinia의 전역 상태로도 저장하도록 했습니다.
- pinia에 토큰의 여부에 따라 login 상태를 확인하도록 했습니다.
- 로그인 상태 여부에 따라 리디렉트했습니다(로그인 전 : 로그인, 회원가입 페이지에만 접근 가능, 로그인 후 : 로그인, 회원가입 페이지 접근 불가)
- 페이지 접근은 회원 정보 조회가 완성되고, 페이지들 연결이 진행되면서 수정될 것 같습니다.
- 분리되어 있는 api 요청 함수들을 authStore에서 사용해서 전역 상태 관리를 추가했습니다.

---

## ✅ 체크리스트

- [x] 로그인 여부에 따른 페이지 이동이 다른지 확인했습니다.
- [x] 피니아에 토큰 값이 저장되는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
 컴포넌트에서 요청 보내는 함수 api는 분리되어 있는 api 함수들이 아니라, 한 번 감싸진 `authStore에 선언된 함수들을 사용`하면 api 요청들을 관리하는 데 좋을 것 같다는 생각이 들었습니다! - `혹시 다른 의견이나 더 좋은 방법을 알고 계시면 말씀해주세요!!`

 ```
 [1] api/폴더 (axios 요청 정의)
    └ loginApi.js → 실제 HTTP 요청만 담당

[2] stores/AuthStore.js (Pinia)
    └ login() → loginApi 호출 + accessToken 저장 등 상태 관리

[3] 화면 컴포넌트
    └ useAuthStore().login() 호출
```