### PR TITLE
fix: 홈화면에서 레벨업 하면 모달창 뜨도록 설정

### DIFF
--- a/src/views/home/HomeView.vue
+++ b/src/views/home/HomeView.vue
@@ -117,8 +117,7 @@
     <BottomNavigation />
     <RewardModal
       v-if="showModal"
-      title="레벨 * 달성
-      축하합니다!"
+      :title="'레벨 ' + USER_PROFILE.userLevel + ' 달성 \n 축하합니다!'"
       message="꾸준한 미션 수행으로 추구미를 향해 멋지게 성장하고 있어요 👏
        기프티콘 발송을 위해 휴대폰 번호를 입력해주세요.
        입력된 번호는 보상 발송 목적 외에는 사용되지 않으며, 사용 후 즉시 폐기됩니다."
@@ -206,7 +205,7 @@ const addAccount = () => {
   });
 };
 
-const showModal = ref(true);
+const showModal = ref(USER_PROFILE.isLevelUp);
 
 function handlePhoneSubmit(phoneNumber) {
   console.log('제출된 전화번호:', phoneNumber);


### PR DESCRIPTION
## 📝 변경 내용

- 홈화면에서 레벨업이 되었을 때만 모달창이 뜨도록 설정

---

## ✅ 체크리스트

- [x] isLevelUp의 값이 true일 때만 모달창이 뜨는것을 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

원래 홈화면과 랭킹화면의 모달 모두 수정하려고 했는데 
랭킹화면의 구조를 바꾸고 설정을 바꿔야 할 것 같아서 일단 홈화면만 수정하였습니다.
이런 경우에는 브랜치 명을 수정하는 것이 좋을까요??