### PR TITLE
feat: homeview 사용자 정보 api 연동

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -64,4 +64,14 @@ const login = async (email, password) => {
   }
 };
 
-export default { checkName, sendCode, verifyCode, signup, login };
+// 유저 프로필 정보
+const userInfo = async () => {
+  try {
+    const { data } = await axiosInstance.get('api/users/main-profile');
+    return data;
+  } catch {
+    throw new Error('유저 프로필 정보 불러오기 실패');
+  }
+};
+
+export default { checkName, sendCode, verifyCode, signup, login, userInfo };

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,6 +1,6 @@
 import axiosInstance from './axios';
 
-const checkName = async name => {
+export const checkName = async name => {
   try {
     const { data } = await axiosInstance.get(`api/users/check-nickname`, {
       params: {
@@ -14,7 +14,7 @@ const checkName = async name => {
 };
 
 //이메일로 인증코드 전송
-const sendCode = async email => {
+export const sendCode = async email => {
   try {
     const { data } = await axiosInstance.post('api/email-auth/send', email);
     return data;
@@ -24,7 +24,7 @@ const sendCode = async email => {
 };
 
 //인증코드 검증
-const verifyCode = async verifyEmail => {
+export const verifyCode = async verifyEmail => {
   try {
     const { data } = await axiosInstance.post(
       'api/email-auth/verify',
@@ -37,7 +37,7 @@ const verifyCode = async verifyEmail => {
 };
 
 //회원가입
-const signup = async signupData => {
+export const signup = async signupData => {
   try {
     const { data } = await axiosInstance.post('api/users/signup', signupData, {
       headers: {
@@ -52,7 +52,7 @@ const signup = async signupData => {
 };
 
 // 로그인
-const login = async (email, password) => {
+export const login = async (email, password) => {
   try {
     const { data } = await axiosInstance.post('api/users/login', {
       email,
@@ -73,5 +73,3 @@ export const userInfo = async () => {
     throw new Error('유저 프로필 정보 불러오기 실패');
   }
 };
-
-export default { checkName, sendCode, verifyCode, signup, login, userInfo };

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -65,7 +65,7 @@ const login = async (email, password) => {
 };
 
 // 유저 프로필 정보
-const userInfo = async () => {
+export const userInfo = async () => {
   try {
     const { data } = await axiosInstance.get('api/users/main-profile');
     return data;

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import authApi from '@/api/authApi';
+import { login } from '@/api/authApi';
 
 export const useAuthStore = defineStore('auth', {
   // 저장소 상태 정의
@@ -66,7 +66,7 @@ export const useAuthStore = defineStore('auth', {
     // ✅ 로그인 액션
     async login(email, password) {
       try {
-        const response = await authApi.login(email, password);
+        const response = await login(email, password);
 
         // ✅ 토큰 저장 (Pinia + localStorage)
         this.setAccessToken(response.accessToken);

--- a/src/views/home/HomeView.vue
+++ b/src/views/home/HomeView.vue
@@ -31,13 +31,7 @@
           </div>
           <!-- 현재 레벨 & 점수 -->
           <div class="text-center text-limegreen-700 text-xs">
-            {{
-              'Lv.' +
-              USER_PROFILE.userLevel +
-              ' / ' +
-              USER_PROFILE.userScore +
-              '점'
-            }}
+            {{ 'Lv.' + userLevel + ' / ' + USER_PROFILE.userScore + '점' }}
           </div>
         </div>
         <!-- 현재 순위 & 최근 성적 -->
@@ -147,10 +141,11 @@ const router = useRouter();
 // 계좌목록 데이터
 const ACCOUNTS = ref([]);
 
+const userLevel = ref(0);
+
 const USER_PROFILE = {
   choogoomiName: 'A',
   nickname: '멜랑콜리',
-  userLevel: 0,
   userScore: 30,
   userRanking: 20,
   isLevelUp: false,
@@ -158,7 +153,7 @@ const USER_PROFILE = {
 
 const choogoomi = CHOOGOOMI_MAP.find(
   item => item.choogoomiName === USER_PROFILE.choogoomiName
-).userLevel[USER_PROFILE.userLevel];
+).userLevel[userLevel.value];
 
 // 캐릭터 이미지 주소 가져오기
 const choogoomiImage = new URL(choogoomi.character, import.meta.url).href;
@@ -169,6 +164,9 @@ const getBankInfo = bankId =>
 onMounted(async () => {
   try {
     const data = await fetchAccounts();
+
+    // 점수로 레벨 계산
+    userLevel.value = getLevel(data.userScore);
 
     // 계좌 목록에 은행 이름과 로고 추가
     ACCOUNTS.value = data.map(account => {

--- a/src/views/home/TransactionView.vue
+++ b/src/views/home/TransactionView.vue
@@ -42,7 +42,7 @@
               {{ transaction.formattedTime }}
             </p>
             <p class="text-sm text-limegreen-800 text-medium">
-              {{ transaction.trDesc2 }}
+              {{ transaction.trDesc3 }}
             </p>
           </div>
 

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -25,7 +25,7 @@
               <button
                 class="flex-1 w-full h-11 text-white bg-limegreen-500 rounded-[10px] disabled:opacity-50"
                 type="button"
-                @click="checkName"
+                @click="handleCheckName"
                 :disabled="isNameChecking"
               >
                 {{ isNameChecking ? '확인 중...' : '중복 확인' }}
@@ -142,7 +142,7 @@
 <script setup>
 import { reactive, ref } from 'vue';
 
-import authApi from '@/api/authApi';
+import { checkName } from '@/api/authApi';
 import AlertModal from '@/components/AlertModal.vue';
 import ConfirmModal from '@/components/ConfirmModal.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
@@ -185,7 +185,7 @@ const onNicknameInput = () => {
 };
 
 //닉네임 중복 체크
-const checkName = async () => {
+const handleCheckName = async () => {
   if (isNameChecking.value) return; // 중복 요청 방지
 
   if (!newNickname.value.trim()) {
@@ -202,7 +202,7 @@ const checkName = async () => {
 
   isNameChecking.value = true;
   try {
-    const result = await authApi.checkName(newNickname.value);
+    const result = await checkName(newNickname.value);
 
     if (result) {
       nameErrorMessage.value = '이미 사용중인 닉네임 입니다.';

--- a/src/views/signup/SignupView.vue
+++ b/src/views/signup/SignupView.vue
@@ -24,7 +24,7 @@
                 />
                 <button
                   class="flex-1 w-full h-11 text-white bg-limegreen-500 rounded-lg disabled:opacity-50"
-                  @click="checkName"
+                  @click="handleCheckName"
                   type="button"
                   :disabled="isNameChecking"
                 >
@@ -155,7 +155,7 @@
 import { reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import authApi from '@/api/authApi';
+import { checkName, sendCode, signup, verifyCode } from '@/api/authApi';
 import AlertModal from '@/components/AlertModal.vue';
 
 import TermsAgreement from './components/terms/TermsAgreement.vue';
@@ -211,7 +211,7 @@ const verifyEmail = reactive({
 });
 
 //닉네임 중복 체크
-const checkName = async () => {
+const handleCheckName = async () => {
   if (isNameChecking.value) return; // 중복 요청 방지
 
   if (!member.nickname.trim()) {
@@ -222,7 +222,7 @@ const checkName = async () => {
 
   isNameChecking.value = true;
   try {
-    const result = await authApi.checkName(member.nickname);
+    const result = await checkName(member.nickname);
 
     if (result) {
       nameErrorMessage.value = '이미 사용중인 닉네임 입니다.';
@@ -250,7 +250,7 @@ const send = async () => {
 
   isSendingEmail.value = true;
   try {
-    await authApi.sendCode(email);
+    await sendCode(email);
     isSendEmailSuccess.value = true;
   } catch (error) {
     emailErrorMessage.value = '이메일 전송 중 오류가 발생했습니다.';
@@ -275,7 +275,7 @@ const verify = async () => {
 
   isVerifyingEmail.value = true;
   try {
-    const result = await authApi.verifyCode(verifyPayload);
+    const result = await verifyCode(verifyPayload);
 
     if (result) {
       emailErrorMessage.value = '인증이 완료되었습니다.';
@@ -344,7 +344,7 @@ const handleSubmit = async () => {
       choogooMi: member.choogooMi,
     };
 
-    await authApi.signup(signupData);
+    await signup(signupData);
 
     isSignupSuccess.value = true;
   } finally {


### PR DESCRIPTION
## 📝 변경 내용

- 거래내역 메모: trDesc2 -> trDesc3 (신한체크 -> 매머드커피)
- 사용자 점수에 따라 자동으로 Level 계산
- 사용자 정보 api를 통해 서버에서 받아옴
- api/authApi.js에서 'userInfo' 함수를 named export 방식으로 변경

---

## ✅ 체크리스트

- [x] userlevel이 점수에 따라 자동으로 계산됨을 확인했습니다.
- [x] api로 연동된 사용자 정보가 잘 출력됨을 확인했습니다.  

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

- api/authApi.js에서 'userInfo' 함수를 named export 방식으로 변경
: export default를 하면 import 시 'authApi' 전체를 가져온 뒤 사용할 때 'authApi.userInfo'로 사용해야 함.
-> 저는 개인적으로 import할 때 전체 파일을 가져오는 것보다
`import { userInfo } from ~`
처럼 내가 필요한 함수만 가져와서 사용하는 것을 선호해서 이렇게 잠시 바꾸었습니다!
별 거 아닌 부분이지만 api파일들을 named export (export const ~) / export default 방식 중 하나로 통일하면 좋을 것 같습니다!
