### PR TITLE
feat : 회원정보 수정 api 연동

### DIFF
--- a/src/components/AlertModal.vue
+++ b/src/components/AlertModal.vue
@@ -19,7 +19,7 @@
         </slot>
       </div>
       <div class="text-limegreen-900 text-2xl font-jua mb-2">{{ title }}</div>
-      <div class="text-gray-400 text-base mb-6 text-center">
+      <div class="text-gray-400 text-base mb-6 text-center whitespace-pre-line">
         {{ message }}
       </div>
       <button

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -59,6 +59,7 @@ export const useAuthStore = defineStore('auth', {
       // ✅ localStorage에서도 제거
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
+      localStorage.removeItem('userEmail');
 
       console.log('✅ 인증 정보 초기화 완료');
     },
@@ -71,6 +72,9 @@ export const useAuthStore = defineStore('auth', {
         // ✅ 토큰 저장 (Pinia + localStorage)
         this.setAccessToken(response.accessToken);
         this.setRefreshToken(response.refreshToken);
+
+        //이메일도 localStorage에 저장
+        localStorage.setItem('userEmail', email);
 
         console.log('✅ 로그인 성공 - 토큰 저장 완료');
         return true;

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -186,7 +186,6 @@ const showErrorModal = ref(false);
 
 //항목별 인증 여부 확인
 const isNameChecked = ref(false);
-const isCurrnetPwdChecked = ref(false);
 const isNewPwdChecked = ref(false);
 
 // 로딩 상태 관리
@@ -233,17 +232,6 @@ const checkName = async () => {
   }
 };
 
-//현재 비밀번호 일치 여부 확인
-const validateCurrentPassword = () => {
-  if (!currentPassword.value.trim()) {
-    CurrnetPwdErrorMessage.value = '비밀번호를 입력해주세요.';
-    return false;
-  }
-  CurrnetPwdErrorMessage.value = '';
-  isCurrnetPwdChecked.value = true;
-  return true;
-};
-
 //새 비밀번호 일치 여부 확인
 const validateNewPassword = () => {
   if (!newPassword.value.trim() || !newPassword.value.trim()) {
@@ -268,10 +256,6 @@ const handleUpdate = async () => {
     hasError = true;
   }
 
-  if (!isCurrnetPwdChecked.value) {
-    hasError = true;
-  }
-
   if (!isNewPwdChecked.value) {
     NewPwdErrorMessage.value = '비밀번호가 일치하지 않습니다.';
     hasError = true;
@@ -284,7 +268,6 @@ const handleUpdate = async () => {
     editedProfile.password = currentPassword.value;
     editedProfile.newPassword = newPassword.value;
   } finally {
-    console.log(member);
     showConfirmModal.value = true;
   }
 };
@@ -305,12 +288,10 @@ const submitUpdate = async () => {
 onMounted(async () => {
   try {
     const { data } = await axiosInstance.get('/api/users/main-profile');
-    console.log(data);
 
     //userInfo에 저장
     Object.assign(member, data);
     newNickname.value = member.nickname;
-    console.log(member);
   } catch (error) {
     console.error('회원 정보 불러오기 실패');
   }

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -235,7 +235,7 @@ const handleCheckName = async () => {
 
 //새 비밀번호 일치 여부 확인
 const validateNewPassword = () => {
-  if (!newPassword.value.trim() || !newPassword.value.trim()) {
+  if (!newPassword.value.trim() || !newPassword2.value.trim()) {
     NewPwdErrorMessage.value = '비밀번호를 입력해주세요.';
     return false;
   }

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -140,23 +140,24 @@
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 
 import authApi from '@/api/authApi';
+import axiosInstance from '@/api/axios';
 import AlertModal from '@/components/AlertModal.vue';
 import ConfirmModal from '@/components/ConfirmModal.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 import router from '@/router';
 
 const member = reactive({
-  profileImage: null,
-  email: 'test@test.com',
-  password: '3333',
-  nickname: '카카오대학교라이언',
-  choogooMi: 'A',
+  choogoomiName: '',
+  nickname: '',
+  userScore: null,
+  userRanking: null,
+  isLevelUp: false,
 });
 
-const newNickname = ref(member.nickname);
+const newNickname = ref('');
 const currentPassword = ref('');
 const newPassword = ref(''); //비밀번호 확인
 const newPassword2 = ref(''); //비밀번호 확인
@@ -279,4 +280,18 @@ const handleUpdate = async () => {
     showConfirmModal.value = true;
   }
 };
+
+onMounted(async () => {
+  try {
+    const { data } = await axiosInstance.get('/api/users/main-profile');
+    console.log(data);
+
+    //userInfo에 저장
+    Object.assign(member, data);
+    newNickname.value = member.nickname;
+    console.log(member);
+  } catch (error) {
+    console.error('회원 정보 불러오기 실패');
+  }
+});
 </script>

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -128,7 +128,7 @@
       :cancelBtn="'취소'"
       :confirmBtn="'확인'"
       @cancel="showConfirmModal = false"
-      @confirm="showAlertModal = true"
+      @confirm="submitUpdate"
     />
     <AlertModal
       v-if="showAlertModal"
@@ -155,6 +155,12 @@ const member = reactive({
   userScore: null,
   userRanking: null,
   isLevelUp: false,
+});
+
+const editedProfile = reactive({
+  nickname: '',
+  password: '',
+  newPassword: '',
 });
 
 const newNickname = ref('');
@@ -226,10 +232,6 @@ const validateCurrentPassword = () => {
     CurrnetPwdErrorMessage.value = '비밀번호를 입력해주세요.';
     return false;
   }
-  if (currentPassword.value !== member.password) {
-    CurrnetPwdErrorMessage.value = '비밀번호가 일치하지 않습니다.';
-    return false;
-  }
   CurrnetPwdErrorMessage.value = '';
   isCurrnetPwdChecked.value = true;
   return true;
@@ -260,7 +262,6 @@ const handleUpdate = async () => {
   }
 
   if (!isCurrnetPwdChecked.value) {
-    CurrnetPwdErrorMessage.value = '비밀번호가 일치하지 않습니다.';
     hasError = true;
   }
 
@@ -272,12 +273,24 @@ const handleUpdate = async () => {
   if (hasError) return;
 
   try {
-    //비밀번호 필드에 수정된 비밀번호 넣기
-    member.password = newPassword.value;
-    member.nickname = newNickname.value;
+    editedProfile.nickname = newNickname.value;
+    editedProfile.password = currentPassword.value;
+    editedProfile.newPassword = newPassword.value;
   } finally {
     console.log(member);
     showConfirmModal.value = true;
+  }
+};
+
+const submitUpdate = async () => {
+  try {
+    console.log(editedProfile);
+    await axiosInstance.put('/api/users/update', editedProfile);
+    showConfirmModal.value = false;
+    showAlertModal.value = true;
+  } catch (error) {
+    showConfirmModal.value = false;
+    console.error('회원 정보 수정 실패:', error);
   }
 };
 

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -136,6 +136,12 @@
       message="회원 정보가 수정되었습니다."
       @close="router.push('/mypage')"
     />
+    <AlertModal
+      v-if="showErrorModal"
+      title="회원 정보 수정"
+      message="회원 정보가 수정에 실패했습니다. 다시 시도해주세요."
+      @close="showErrorModal = false"
+    />
   </div>
 </template>
 
@@ -176,6 +182,7 @@ const NewPwdErrorMessage = ref('');
 //모달창 관리
 const showConfirmModal = ref(false);
 const showAlertModal = ref(false);
+const showErrorModal = ref(false);
 
 //항목별 인증 여부 확인
 const isNameChecked = ref(false);

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -44,7 +44,7 @@
         <div class="mb-5">
           <label for="email" class="mb-1 block font-bold">이메일</label>
           <input
-            v-model="member.email"
+            v-model="userEmail"
             id="email"
             type="email"
             class="border-2 border-limegreen-500 flex-2 w-full h-11 rounded-lg bg-limegreen-100 px-3 py-3 text-limegreen-700"
@@ -169,6 +169,7 @@ const editedProfile = reactive({
   newPassword: '',
 });
 
+const userEmail = ref('');
 const newNickname = ref('');
 const currentPassword = ref('');
 const newPassword = ref(''); //비밀번호 확인
@@ -292,6 +293,7 @@ onMounted(async () => {
     //userInfo에 저장
     Object.assign(member, data);
     newNickname.value = member.nickname;
+    userEmail.value = localStorage.getItem('userEmail');
   } catch (error) {
     console.error('회원 정보 불러오기 실패');
   }

--- a/src/views/mypage/MyPageEditInfoView.vue
+++ b/src/views/mypage/MyPageEditInfoView.vue
@@ -139,7 +139,7 @@
     <AlertModal
       v-if="showErrorModal"
       title="회원 정보 수정"
-      message="회원 정보가 수정에 실패했습니다. 다시 시도해주세요."
+      :message="'회원 정보 수정에 실패했습니다.\n다시 시도해주세요.'"
       @close="showErrorModal = false"
     />
   </div>
@@ -297,6 +297,7 @@ const submitUpdate = async () => {
     showAlertModal.value = true;
   } catch (error) {
     showConfirmModal.value = false;
+    showErrorModal.value = true;
     console.error('회원 정보 수정 실패:', error);
   }
 };

--- a/src/views/mypage/MyPageView.vue
+++ b/src/views/mypage/MyPageView.vue
@@ -156,7 +156,6 @@ const logout = () => {
 onMounted(async () => {
   try {
     const { data } = await axiosInstance.get('/api/users/main-profile');
-    console.log(data);
 
     //userScore로 레벨 계산
     userLevel.value = getLevel(data.userScore);

--- a/src/views/mypage/MyPageView.vue
+++ b/src/views/mypage/MyPageView.vue
@@ -156,6 +156,7 @@ const logout = () => {
 onMounted(async () => {
   try {
     const { data } = await axiosInstance.get('/api/users/main-profile');
+    console.log(data);
 
     //userScore로 레벨 계산
     userLevel.value = getLevel(data.userScore);
@@ -164,13 +165,16 @@ onMounted(async () => {
     const choogoomi = CHOOGOOMI_MAP.find(
       choogoomi => choogoomi.choogoomiName === data.choogooMi
     );
+
+    const choogoomiName = choogoomi.userLevel[0].choogoomiType;
+
     choogoomiImage.value = new URL(
       choogoomi.userLevel[userLevel.value].character,
       import.meta.url
     ).href;
 
     // userInfo 업데이트
-    userInfo.choogoomiName = choogoomi.choogoomiType;
+    userInfo.choogoomiName = choogoomiName;
     userInfo.nickname = data.nickname;
     userInfo.userScore = data.userScore;
     userInfo.userRanking = data.userRanking;


### PR DESCRIPTION
# 📌 회원정보 수정 페이지 api 연동

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 회원정보 수정 페이지에서 현재 사용자의 닉네임 표시
- 이메일 중복확인, 새 비밀번호 확인 기능 추가
- 수정 완료 버튼 클릭시 확인 모달창 표시
- api 요청 후 회원가입 실패시 실패 모달창 표시
- 회원 정보 수정 페이지에서 로그인한 사용자의 이메일 표시


---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 현재 사용자의 정보가 회원정보 수정 페이지에 표시되는지 확인했습니다.
- [x] 회원정보 수정 api가 잘 요청되는지 확인했습니다.
- [x] 회원정보 요청 api가 잘 작동하는지 확인했습니다.

---

## 📷 스크린샷(선택)
<img width="243" height="435" alt="localhost_5173_login(노트북)" src="https://github.com/user-attachments/assets/8430f352-a882-4a77-9d76-7dc97282b192" />

<img width="243" height="435" alt="정보수정 모달" src="https://github.com/user-attachments/assets/8f89c418-2ae7-4593-af60-fd64121cbd59" />

<img width="243" height="435" alt="정보 수정 에러 모달" src="https://github.com/user-attachments/assets/132fd515-7eac-4c42-9f01-2d85007d574c" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항
<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
