### PR TITLE
feat: 랭킹 페이지 api 연결

### DIFF
--- a/src/api/ranking.js
+++ b/src/api/ranking.js
@@ -1,0 +1,19 @@
+import axiosInstance from '@/api/axios';
+
+export const fetchRankingList = async () => {
+  try {
+    const response = await axiosInstance.get('/api/ranking/list/top50');
+    return response.data;
+  } catch {
+    return false;
+  }
+};
+
+export const fetchLastRankingList = async () => {
+  try {
+    const response = await axiosInstance.get('/api/ranking/list/previous/top3');
+    return response.data;
+  } catch {
+    return false;
+  }
+};

--- a/src/api/ranking.js
+++ b/src/api/ranking.js
@@ -17,3 +17,12 @@ export const fetchLastRankingList = async () => {
     return false;
   }
 };
+
+export const updateRankingData = async () => {
+  try {
+    await axiosInstance.put('/api/ranking/update');
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src/constants/rewardList.js
+++ b/src/constants/rewardList.js
@@ -1,6 +1,6 @@
 export const REWARD_LIST = [
   {
-    choogoomiName: 'A',
+    choogoomiName: '지출제로형',
     rewards: {
       1: '다이소 상품권 2만원',
       2: '편의점 상품권 1만원',
@@ -8,7 +8,7 @@ export const REWARD_LIST = [
     },
   },
   {
-    choogoomiName: 'B',
+    choogoomiName: '합리소비형',
     rewards: {
       1: '배달앱 상품권 2만원',
       2: '백화점 상품권 1만원',
@@ -16,7 +16,7 @@ export const REWARD_LIST = [
     },
   },
   {
-    choogoomiName: 'C',
+    choogoomiName: '저축실천형',
     rewards: {
       1: '네이버페이 포인트 2만원',
       2: '네이버페이 포인트 1만원',
@@ -24,7 +24,7 @@ export const REWARD_LIST = [
     },
   },
   {
-    choogoomiName: 'D',
+    choogoomiName: '투자도전형',
     rewards: {
       1: '깨비증권 쿠폰 2만원',
       2: '깨비증권 쿠폰 1만원',
@@ -32,7 +32,7 @@ export const REWARD_LIST = [
     },
   },
   {
-    choogoomiName: 'E',
+    choogoomiName: '금융탐구형',
     rewards: {
       1: '도서상품권 2만원',
       2: '도서상품권 1만원',

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -124,30 +124,30 @@
           class="max-h-[calc(100vh-450px)] overflow-scroll [&::-webkit-scrollbar]:hidden bg-limegreen-500 mx-3 mb-1 space-y-2"
         >
           <div
-            v-for="(rank, i) in RANKING_LIST"
-            :key="i"
+            v-for="user in currentRankingList"
+            :key="user.ranking"
             class="bg-white rounded-xl px-5 py-2 flex justify-between items-center"
           >
             <div class="flex items-center gap-3">
               <div class="text-lg font-semibold text-limegreen-800">
-                {{ rank.ranking }}
+                {{ user.ranking }}
               </div>
               <div class="flex flex-col items-center ml-1">
                 <img
-                  :src="getProfileImage(rank)"
+                  :src="getProfileImage(user)"
                   class="bg-limegreen-100 rounded-full size-10"
                 />
                 <span
                   class="bg-green text-white mt-[-7px] px-2 py-[2.5px] rounded-full text-[7px] text-center"
                 >
-                  {{ getChoogoomiType(rank) }}
+                  {{ getChoogoomiType(user) }}
                 </span>
               </div>
               <div class="flex flex-col">
                 <span class="text-sm font-medium text-limegreen-900">{{
-                  rank.userNickname
+                  user.userNickname
                 }}</span>
-                <span class="text-xs text-gray-500">{{ rank.score }}점</span>
+                <span class="text-xs text-gray-500">{{ user.score }}점</span>
               </div>
             </div>
             <div
@@ -156,9 +156,9 @@
               <img
                 :src="rankChange"
                 class="size-2 mr-1"
-                :class="{ 'rotate-180': rank.ranking - rank.befRanking > 0 }"
+                :class="{ 'rotate-180': user.ranking - user.beforeRanking > 0 }"
               />
-              <span>{{ Math.abs(rank.ranking - rank.befRanking) }}</span>
+              <span>{{ Math.abs(user.ranking - user.beforeRanking) }}</span>
             </div>
           </div>
         </div>
@@ -184,7 +184,7 @@
 <script setup>
 import { onMounted, ref } from 'vue';
 
-import { fetchLastRankingList } from '@/api/ranking.js';
+import { fetchLastRankingList, fetchRankingList } from '@/api/ranking.js';
 import icon_info from '@/assets/img/icons/feature/icon_info.png';
 import rankChange from '@/assets/img/icons/feature/icon_rankChange.png';
 import BottomNavigation from '@/components/BottomNavigation.vue';
@@ -212,12 +212,18 @@ const USER_PROFILE = {
 };
 
 const lastRankingList = ref([]);
+const currentRankingList = ref([]);
 const firstRankUser = ref({});
 const secondRankUser = ref({});
 const thirdRankUser = ref({});
 
 const fetchLastRankingData = async () => {
   const response = await fetchLastRankingList();
+  return response;
+};
+
+const fetchCurrentRankingData = async () => {
+  const response = await fetchRankingList();
   return response;
 };
 
@@ -229,80 +235,12 @@ onMounted(async () => {
   firstRankUser.value = lastRankingList.value[0];
   secondRankUser.value = lastRankingList.value[1];
   thirdRankUser.value = lastRankingList.value[2];
-});
 
-const RANKING_LIST = [
-  {
-    ranking: 1,
-    userNickname: '심쿵비비',
-    befRanking: 2,
-    score: 900,
-    choogoomiName: 'C',
-  },
-  {
-    ranking: 2,
-    userNickname: '어피치',
-    befRanking: 3,
-    score: 900,
-    choogoomiName: 'C',
-  },
-  {
-    ranking: 3,
-    userNickname: '라이언',
-    befRanking: 5,
-    score: 900,
-    choogoomiName: 'C',
-  },
-  {
-    ranking: 4,
-    userNickname: '프로도',
-    befRanking: 6,
-    score: 900,
-    choogoomiName: 'A',
-  },
-  {
-    ranking: 5,
-    userNickname: '춘식이',
-    befRanking: 7,
-    score: 900,
-    choogoomiName: 'B',
-  },
-  {
-    ranking: 6,
-    userNickname: '멜랑콜리',
-    befRanking: 8,
-    score: 900,
-    choogoomiName: 'D',
-  },
-  {
-    ranking: 7,
-    userNickname: '롤로라무',
-    befRanking: 10,
-    score: 900,
-    choogoomiName: 'E',
-  },
-  {
-    ranking: 8,
-    userNickname: '포스아거',
-    befRanking: 1,
-    score: 900,
-    choogoomiName: 'A',
-  },
-  {
-    ranking: 9,
-    userNickname: '루나키키',
-    befRanking: 4,
-    score: 900,
-    choogoomiName: 'B',
-  },
-  {
-    ranking: 10,
-    userNickname: '무지',
-    befRanking: 11,
-    score: 900,
-    choogoomiName: 'D',
-  },
-];
+  const currentData = await fetchCurrentRankingData();
+  currentRankingList.value = currentData.map(user => ({
+    ...user,
+  }));
+});
 
 // 유저 닉네임이 지난주 랭킹 top3에 포함되면 모달 표시
 if (

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -151,12 +151,22 @@
               </div>
             </div>
             <div
-              class="flex items-center text-xs text-red font-semibold leaning-none"
+              class="flex items-center text-xs font-semibold leaning-none"
+              :class="{
+                'text-limegreen-900': user.ranking - user.beforeRanking === 0,
+                'text-red': user.ranking - user.beforeRanking < 0,
+                'text-blue-500': user.ranking - user.beforeRanking > 0,
+              }"
             >
               <img
+                v-if="user.ranking - user.beforeRanking !== 0"
                 :src="rankChange"
                 class="size-2 mr-1"
-                :class="{ 'rotate-180': user.ranking - user.beforeRanking > 0 }"
+                :class="{
+                  'rotate-180': user.ranking - user.beforeRanking > 0,
+                  'icon-red': user.ranking - user.beforeRanking < 0,
+                  'icon-blue': user.ranking - user.beforeRanking > 0,
+                }"
               />
               <span>{{ Math.abs(user.ranking - user.beforeRanking) }}</span>
             </div>
@@ -294,3 +304,16 @@ function handlePhoneSubmit(phoneNumber) {
   console.log('제출된 전화번호:', phoneNumber);
 }
 </script>
+
+<style scoped>
+/* 아이콘 색상 변경을 위한 CSS 필터 */
+.icon-red {
+  filter: brightness(0) saturate(100%) invert(15%) sepia(89%) saturate(7500%)
+    hue-rotate(359deg) brightness(95%) contrast(107%);
+}
+
+.icon-blue {
+  filter: brightness(0) saturate(100%) invert(26%) sepia(100%) saturate(4625%)
+    hue-rotate(213deg) brightness(95%) contrast(106%);
+}
+</style>

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -10,7 +10,7 @@
         <div class="relative">
           <p class="text-lg text-limegreen-800 mb-3 text-center">명예의 전당</p>
           <div
-            class="absolute top-1/2 left-1/2 translate-x-[45px] pb-3 -translate-y-1.5 group"
+            class="absolute top-1/2 left-1/2 translate-x-[45px] pb-3 -translate-y-1.5 group z-10"
           >
             <img
               :src="icon_info"

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -207,6 +207,7 @@
 <script setup>
 import { onMounted, ref } from 'vue';
 
+import { userInfo } from '@/api/authApi.js';
 import {
   fetchLastRankingList,
   fetchRankingList,
@@ -231,13 +232,7 @@ const aboutReward = {
   content: `매주 월요일, 지난주 점수를 기준으로 집계됩니다.\n 순위별로 유형별 맞춤 상품이 차등 지급될 예정입니다.`,
 };
 
-const USER_PROFILE = {
-  choogoomiName: 'A',
-  nickname: '',
-  userScore: 500,
-  userRanking: 20,
-  isLevelUp: false,
-};
+const userProfile = ref({});
 
 const lastRankingList = ref([]);
 const currentRankingList = ref([]);
@@ -261,6 +256,8 @@ const fetchCurrentRankingData = async () => {
 const loadRankingData = async () => {
   try {
     isLoading.value = true;
+    const userData = await userInfo();
+    Object.assign(userProfile.value, userData);
 
     // 1. 랭킹 업데이트 (선택적)
     const updateResult = await updateRankingData();
@@ -299,7 +296,7 @@ onMounted(() => {
 // 유저 닉네임이 지난주 랭킹 top3에 포함되면 모달 표시
 if (
   [firstRankUser, secondRankUser, thirdRankUser].some(
-    user => user && user.userNickname === USER_PROFILE.nickname
+    user => user && user.userNickname === userProfile.value.nickname
   )
 ) {
   showModal.value = true;
@@ -346,6 +343,7 @@ const getProfileImage = userData => {
 
 function handlePhoneSubmit(phoneNumber) {
   console.log('제출된 전화번호:', phoneNumber);
+  showModal.value = false;
 }
 </script>
 

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -1,206 +1,221 @@
 <template>
   <div class="relative flex justify-center w-full h-full">
-    <TopNavigation />
-    <div class="mt-14 w-full">
-      <div class="relative">
-        <p class="text-lg text-limegreen-800 mb-3 text-center">명예의 전당</p>
-        <div
-          class="absolute top-1/2 left-1/2 translate-x-[45px] pb-3 -translate-y-1.5 group"
-        >
-          <img
-            :src="icon_info"
-            alt="정보 아이콘"
-            class="size-3.5 cursor-pointer"
-          />
-          <!-- hover 이벤트 -->
+    <!-- 로딩 중일 때 LoadingScreen 표시 -->
+    <LoadingScreen v-if="isLoading" />
+
+    <!-- 정상 데이터 표시 -->
+    <template v-else>
+      <TopNavigation />
+      <div class="mt-14 w-full">
+        <div class="relative">
+          <p class="text-lg text-limegreen-800 mb-3 text-center">명예의 전당</p>
           <div
-            class="absolute top-full -translate-x-[65%] w-75 bg-white border-none text-center rounded-xl shadow-sm drop-shadow-[0_8px_10px_rgba(183,202,112,0.5)] z-20 px-5 py-4 space-y-3 group-hover:block hidden"
+            class="absolute top-1/2 left-1/2 translate-x-[45px] pb-3 -translate-y-1.5 group"
           >
-            <p class="text-green text-3xl mt-3 mb-3">{{ aboutReward.title }}</p>
-            <p class="text-green text-[13px] leading-snug whitespace-pre-line">
-              {{ aboutReward.content }}
-            </p>
+            <img
+              :src="icon_info"
+              alt="정보 아이콘"
+              class="size-3.5 cursor-pointer"
+            />
+            <!-- hover 이벤트 -->
             <div
-              v-for="reward in REWARD_LIST"
-              :key="reward.choogoomiName"
-              class="text-xs leading-tight text-limegreen-800 whitespace-pre-line mt-2 space-y-1"
+              class="absolute top-full -translate-x-[65%] w-75 bg-white border-none text-center rounded-xl shadow-sm drop-shadow-[0_8px_10px_rgba(183,202,112,0.5)] z-20 px-5 py-4 space-y-3 group-hover:block hidden"
             >
-              <div>
-                <p class="text-bold text-[13px] text-yellow">
-                  {{ reward.choogoomiName }}
-                </p>
-              </div>
-              <div v-for="(reward, rank) in reward.rewards" :key="rank">
-                {{ rank + '등: ' + reward }}
+              <p class="text-green text-3xl mt-3 mb-3">
+                {{ aboutReward.title }}
+              </p>
+              <p
+                class="text-green text-[13px] leading-snug whitespace-pre-line"
+              >
+                {{ aboutReward.content }}
+              </p>
+              <div
+                v-for="reward in REWARD_LIST"
+                :key="reward.choogoomiName"
+                class="text-xs leading-tight text-limegreen-800 whitespace-pre-line mt-2 space-y-1"
+              >
+                <div>
+                  <p class="text-bold text-[13px] text-yellow">
+                    {{ reward.choogoomiName }}
+                  </p>
+                </div>
+                <div v-for="(reward, rank) in reward.rewards" :key="rank">
+                  {{ rank + '등: ' + reward }}
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- 지난주 랭킹 명예의 전당 -->
-      <div class="flex gap-1 items-center mb-2 px-6">
-        <!-- 2등 -->
-        <div
-          class="flex flex-1 flex-col items-center w-25 h-40 bg-[#DFF1F9] rounded-xl px-4 pt-3 pb-4"
-        >
-          <span class="text-gray-300 text-lg font-semibold">{{
-            secondRankUser.ranking
-          }}</span>
-          <img
-            :src="getProfileImage(secondRankUser)"
-            class="bg-ivory rounded-full mt-2 size-15 object-cover"
-          />
-          <span
-            class="bg-green text-white mt-[-7px] px-2.5 py-[3px] rounded-full text-[9px] text-center"
-          >
-            {{ getChoogoomiType(secondRankUser) }}
-          </span>
-          <div class="text-[13px] text-limegreen-800 mt-2">
-            {{ secondRankUser.userNickname }}
-          </div>
-          <div class="text-[11px] text-gray-300">
-            {{ secondRankUser.score }}점
-          </div>
-        </div>
-
-        <!-- 1등 -->
-        <div
-          class="flex flex-col items-center h-50 w-32 bg-limegreen-100 rounded-xl px-4 pt-3 pb-4"
-        >
-          <span class="text-yellow text-2xl font-semibold">
-            {{ firstRankUser.ranking }}
-          </span>
-          <img
-            :src="getProfileImage(firstRankUser)"
-            class="bg-ivory rounded-full mt-1 size-20"
-          />
-          <span
-            class="bg-green text-white mt-[-7px] px-2.5 py-[2px] rounded-full text-xs text-center"
-          >
-            {{ getChoogoomiType(firstRankUser) }}
-          </span>
-          <div class="text-[13px] text-limegreen-800 mt-2">
-            {{ firstRankUser.userNickname }}
-          </div>
-          <div class="text-[11px] text-gray-300">
-            {{ firstRankUser.score }}점
-          </div>
-        </div>
-
-        <!-- 3등 -->
-        <div
-          class="flex flex-1 flex-col items-center bg-[#FFE7E7] w-25 h-40 rounded-xl px-4 pt-3 pb-4"
-        >
-          <span class="text-[#F29C3A] text-lg font-semibold">
-            {{ thirdRankUser.ranking }}
-          </span>
-          <img
-            :src="getProfileImage(thirdRankUser)"
-            class="bg-ivory rounded-full mt-2 size-15 object-cover"
-          />
-          <span
-            class="bg-green text-white mt-[-7px] px-2.5 py-[3px] rounded-full text-[9px] text-center"
-          >
-            {{ getChoogoomiType(thirdRankUser) }}
-          </span>
-          <div class="text-[13px] text-limegreen-800 mt-2">
-            {{ thirdRankUser.userNickname }}
-          </div>
-          <div class="text-[11px] text-gray-300">
-            {{ thirdRankUser.score }}점
-          </div>
-        </div>
-      </div>
-
-      <!-- 이번주 실시간 랭킹 -->
-      <div
-        class="flex flex-grow flex-col bg-limegreen-500 rounded-t-[30px] px-3 py-2 w-full h-full mt-4"
-      >
-        <p class="text-lg text-limegreen-900 text-center pt-3 pb-4 px-4">
-          실시간 랭킹
-        </p>
-        <div
-          class="max-h-[calc(100vh-450px)] overflow-scroll [&::-webkit-scrollbar]:hidden bg-limegreen-500 mx-3 mb-1 space-y-2"
-        >
+        <!-- 지난주 랭킹 명예의 전당 -->
+        <div class="flex gap-1 items-center mb-2 px-6">
+          <!-- 2등 -->
           <div
-            v-for="user in currentRankingList"
-            :key="user.ranking"
-            class="bg-white rounded-xl px-5 py-2 flex justify-between items-center"
+            class="flex flex-1 flex-col items-center w-25 h-40 bg-[#DFF1F9] rounded-xl px-4 pt-3 pb-4"
           >
-            <div class="flex items-center gap-3">
-              <div class="text-lg font-semibold text-limegreen-800">
-                {{ user.ranking }}
-              </div>
-              <div class="flex flex-col items-center ml-1">
-                <img
-                  :src="getProfileImage(user)"
-                  class="bg-limegreen-100 rounded-full size-10"
-                />
-                <span
-                  class="bg-green text-white mt-[-7px] px-2 py-[2.5px] rounded-full text-[7px] text-center"
-                >
-                  {{ getChoogoomiType(user) }}
-                </span>
-              </div>
-              <div class="flex flex-col">
-                <span class="text-sm font-medium text-limegreen-900">{{
-                  user.userNickname
-                }}</span>
-                <span class="text-xs text-gray-500">{{ user.score }}점</span>
-              </div>
-            </div>
-            <div
-              class="flex items-center text-xs font-semibold leaning-none"
-              :class="{
-                'text-limegreen-900': user.ranking - user.beforeRanking === 0,
-                'text-red': user.ranking - user.beforeRanking < 0,
-                'text-blue-500': user.ranking - user.beforeRanking > 0,
-              }"
+            <span class="text-gray-300 text-lg font-semibold">{{
+              secondRankUser.ranking
+            }}</span>
+            <img
+              :src="getProfileImage(secondRankUser)"
+              class="bg-ivory rounded-full mt-2 size-15 object-cover"
+            />
+            <span
+              class="bg-green text-white mt-[-7px] px-2.5 py-[3px] rounded-full text-[9px] text-center"
             >
-              <img
-                v-if="user.ranking - user.beforeRanking !== 0"
-                :src="rankChange"
-                class="size-2 mr-1"
+              {{ getChoogoomiType(secondRankUser) }}
+            </span>
+            <div class="text-[13px] text-limegreen-800 mt-2">
+              {{ secondRankUser.userNickname }}
+            </div>
+            <div class="text-[11px] text-gray-300">
+              {{ secondRankUser.score }}점
+            </div>
+          </div>
+
+          <!-- 1등 -->
+          <div
+            class="flex flex-col items-center h-50 w-32 bg-limegreen-100 rounded-xl px-4 pt-3 pb-4"
+          >
+            <span class="text-yellow text-2xl font-semibold">
+              {{ firstRankUser.ranking }}
+            </span>
+            <img
+              :src="getProfileImage(firstRankUser)"
+              class="bg-ivory rounded-full mt-1 size-20"
+            />
+            <span
+              class="bg-green text-white mt-[-7px] px-2.5 py-[2px] rounded-full text-xs text-center"
+            >
+              {{ getChoogoomiType(firstRankUser) }}
+            </span>
+            <div class="text-[13px] text-limegreen-800 mt-2">
+              {{ firstRankUser.userNickname }}
+            </div>
+            <div class="text-[11px] text-gray-300">
+              {{ firstRankUser.score }}점
+            </div>
+          </div>
+
+          <!-- 3등 -->
+          <div
+            class="flex flex-1 flex-col items-center bg-[#FFE7E7] w-25 h-40 rounded-xl px-4 pt-3 pb-4"
+          >
+            <span class="text-[#F29C3A] text-lg font-semibold">
+              {{ thirdRankUser.ranking }}
+            </span>
+            <img
+              :src="getProfileImage(thirdRankUser)"
+              class="bg-ivory rounded-full mt-2 size-15 object-cover"
+            />
+            <span
+              class="bg-green text-white mt-[-7px] px-2.5 py-[3px] rounded-full text-[9px] text-center"
+            >
+              {{ getChoogoomiType(thirdRankUser) }}
+            </span>
+            <div class="text-[13px] text-limegreen-800 mt-2">
+              {{ thirdRankUser.userNickname }}
+            </div>
+            <div class="text-[11px] text-gray-300">
+              {{ thirdRankUser.score }}점
+            </div>
+          </div>
+        </div>
+
+        <!-- 이번주 실시간 랭킹 -->
+        <div
+          class="flex flex-grow flex-col bg-limegreen-500 rounded-t-[30px] px-3 py-2 w-full h-full mt-4"
+        >
+          <p class="text-lg text-limegreen-900 text-center pt-3 pb-4 px-4">
+            실시간 랭킹
+          </p>
+          <div
+            class="max-h-[calc(100vh-450px)] overflow-scroll [&::-webkit-scrollbar]:hidden bg-limegreen-500 mx-3 mb-1 space-y-2"
+          >
+            <div
+              v-for="user in currentRankingList"
+              :key="user.ranking"
+              class="bg-white rounded-xl px-5 py-2 flex justify-between items-center"
+            >
+              <div class="flex items-center gap-3">
+                <div class="text-lg font-semibold text-limegreen-800">
+                  {{ user.ranking }}
+                </div>
+                <div class="flex flex-col items-center ml-1">
+                  <img
+                    :src="getProfileImage(user)"
+                    class="bg-limegreen-100 rounded-full size-10"
+                  />
+                  <span
+                    class="bg-green text-white mt-[-7px] px-2 py-[2.5px] rounded-full text-[7px] text-center"
+                  >
+                    {{ getChoogoomiType(user) }}
+                  </span>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm font-medium text-limegreen-900">{{
+                    user.userNickname
+                  }}</span>
+                  <span class="text-xs text-gray-500">{{ user.score }}점</span>
+                </div>
+              </div>
+              <div
+                class="flex items-center text-xs font-semibold leaning-none"
                 :class="{
-                  'rotate-180': user.ranking - user.beforeRanking > 0,
-                  'icon-red': user.ranking - user.beforeRanking < 0,
-                  'icon-blue': user.ranking - user.beforeRanking > 0,
+                  'text-limegreen-900': user.ranking - user.beforeRanking === 0,
+                  'text-red': user.ranking - user.beforeRanking < 0,
+                  'text-blue-500': user.ranking - user.beforeRanking > 0,
                 }"
-              />
-              <span v-if="user.ranking - user.beforeRanking !== 0">{{
-                Math.abs(user.ranking - user.beforeRanking)
-              }}</span>
-              <span v-else>-</span>
+              >
+                <img
+                  v-if="user.ranking - user.beforeRanking !== 0"
+                  :src="rankChange"
+                  class="size-2 mr-1"
+                  :class="{
+                    'rotate-180': user.ranking - user.beforeRanking > 0,
+                    'icon-red': user.ranking - user.beforeRanking < 0,
+                    'icon-blue': user.ranking - user.beforeRanking > 0,
+                  }"
+                />
+                <span v-if="user.ranking - user.beforeRanking !== 0">{{
+                  Math.abs(user.ranking - user.beforeRanking)
+                }}</span>
+                <span v-else>-</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <BottomNavigation />
+      <BottomNavigation />
 
-    <RewardModal
-      v-if="showModal"
-      title="축하합니다!
+      <RewardModal
+        v-if="showModal"
+        title="축하합니다!
 상위 랭크에 도달했어요."
-      message="보상(기프티콘) 발송을 위해 휴대폰 번호를 입력해주세요.
+        message="보상(기프티콘) 발송을 위해 휴대폰 번호를 입력해주세요.
 입력된 번호는 보상 발송 목적 외에는 사용되지 않으며, 사용 후 즉시 폐기됩니다."
-      caution="‼️ 기회는 단 한 번뿐 ‼️
+        caution="‼️ 기회는 단 한 번뿐 ‼️
 잘못 입력하면 보상을 받을 수 없어요."
-      @submit="handlePhoneSubmit"
-      @close="showModal = false"
-    />
+        @submit="handlePhoneSubmit"
+        @close="showModal = false"
+      />
+    </template>
   </div>
 </template>
 
 <script setup>
 import { onMounted, ref } from 'vue';
 
-import { fetchLastRankingList, fetchRankingList } from '@/api/ranking.js';
+import {
+  fetchLastRankingList,
+  fetchRankingList,
+  updateRankingData,
+} from '@/api/ranking.js';
 import icon_info from '@/assets/img/icons/feature/icon_info.png';
 import rankChange from '@/assets/img/icons/feature/icon_rankChange.png';
 import BottomNavigation from '@/components/BottomNavigation.vue';
+import LoadingScreen from '@/components/LoadingScreen.vue';
 import RewardModal from '@/components/RewardModal.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap.js';
@@ -230,6 +245,9 @@ const firstRankUser = ref({});
 const secondRankUser = ref({});
 const thirdRankUser = ref({});
 
+// 로딩 상태 관리 - 초기값은 true (로딩 중)
+const isLoading = ref(true);
+
 const fetchLastRankingData = async () => {
   const response = await fetchLastRankingList();
   return response;
@@ -239,22 +257,45 @@ const fetchCurrentRankingData = async () => {
   const response = await fetchRankingList();
   return response;
 };
+// 데이터 로딩 함수
+const loadRankingData = async () => {
+  try {
+    isLoading.value = true;
 
-onMounted(async () => {
-  const data = await fetchLastRankingData();
-  lastRankingList.value = data.map(user => ({
-    ...user,
-  }));
-  firstRankUser.value = lastRankingList.value[0];
-  secondRankUser.value = lastRankingList.value[1];
-  thirdRankUser.value = lastRankingList.value[2];
+    // 1. 랭킹 업데이트 (선택적)
+    const updateResult = await updateRankingData();
+    if (!updateResult) {
+      console.warn('랭킹 업데이트 실패 - 기존 데이터 사용');
+    }
 
-  const currentData = await fetchCurrentRankingData();
-  currentRankingList.value = currentData.map(user => ({
-    ...user,
-  }));
+    // 2. 데이터 로딩 (병렬 처리로 성능 향상)
+    const [lastData, currentData] = await Promise.all([
+      fetchLastRankingData(),
+      fetchCurrentRankingData(),
+    ]);
+
+    // 3. 데이터 검증 및 할당
+    if (lastData && currentData) {
+      lastRankingList.value = lastData.map(user => ({ ...user }));
+      currentRankingList.value = currentData.map(user => ({ ...user }));
+
+      firstRankUser.value = lastRankingList.value[0] || {};
+      secondRankUser.value = lastRankingList.value[1] || {};
+      thirdRankUser.value = lastRankingList.value[2] || {};
+
+      //  모든 요청이 성공하면 로딩 완료
+      isLoading.value = false;
+    } else {
+      throw new Error('필수 데이터 로딩 실패');
+    }
+  } catch (error) {
+    isLoading.value = false;
+  }
+};
+
+onMounted(() => {
+  loadRankingData();
 });
-
 // 유저 닉네임이 지난주 랭킹 top3에 포함되면 모달 표시
 if (
   [firstRankUser, secondRankUser, thirdRankUser].some(

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -168,7 +168,10 @@
                   'icon-blue': user.ranking - user.beforeRanking > 0,
                 }"
               />
-              <span>{{ Math.abs(user.ranking - user.beforeRanking) }}</span>
+              <span v-if="user.ranking - user.beforeRanking !== 0">{{
+                Math.abs(user.ranking - user.beforeRanking)
+              }}</span>
+              <span v-else>-</span>
             </div>
           </div>
         </div>

--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -21,22 +21,16 @@
               {{ aboutReward.content }}
             </p>
             <div
-              v-for="choogoomiName in choogoomiNames"
-              :key="choogoomiName"
+              v-for="reward in REWARD_LIST"
+              :key="reward.choogoomiName"
               class="text-xs leading-tight text-limegreen-800 whitespace-pre-line mt-2 space-y-1"
             >
               <div>
                 <p class="text-bold text-[13px] text-yellow">
-                  {{
-                    CHOOGOOMI_MAP.find(c => c.choogoomiName === choogoomiName)
-                      ?.userLevel[0].choogoomiType
-                  }}
+                  {{ reward.choogoomiName }}
                 </p>
               </div>
-              <div
-                v-for="(reward, rank) in rewardMap[choogoomiName]"
-                :key="rank"
-              >
+              <div v-for="(reward, rank) in reward.rewards" :key="rank">
                 {{ rank + '등: ' + reward }}
               </div>
             </div>
@@ -140,13 +134,13 @@
               </div>
               <div class="flex flex-col items-center ml-1">
                 <img
-                  :src="choogoomiCharacter[rank.userNickname]"
+                  :src="getProfileImage(rank)"
                   class="bg-limegreen-100 rounded-full size-10"
                 />
                 <span
                   class="bg-green text-white mt-[-7px] px-2 py-[2.5px] rounded-full text-[7px] text-center"
                 >
-                  {{ choogoomiType[rank.userNickname] }}
+                  {{ getChoogoomiType(rank) }}
                 </span>
               </div>
               <div class="flex flex-col">
@@ -201,13 +195,6 @@ import { REWARD_LIST } from '@/constants/rewardList.js';
 import { getLevel } from '@/utils/levelUtils.js';
 
 // 모달 표시 여부
-const CHOOGOOMI_TYPE = ref({
-  A: '지출제로형',
-  B: '합리소비형',
-  C: '저축실천형',
-  D: '투자도전형',
-  E: '금융탐구형',
-});
 
 const showModal = ref(false);
 
@@ -243,27 +230,6 @@ onMounted(async () => {
   secondRankUser.value = lastRankingList.value[1];
   thirdRankUser.value = lastRankingList.value[2];
 });
-
-const LAST_RANKING_LIST = ref([
-  {
-    userNickname: '쭈꾸미',
-    ranking: 1,
-    score: 500,
-    choogoomiName: 'A',
-  },
-  {
-    userNickname: '오징어',
-    ranking: 2,
-    score: 490,
-    choogoomiName: 'A',
-  },
-  {
-    userNickname: '낙지',
-    ranking: 3,
-    score: 480,
-    choogoomiName: 'A',
-  },
-]);
 
 const RANKING_LIST = [
   {
@@ -385,41 +351,6 @@ const getProfileImage = userData => {
   // 프로필 이미지 경로 반환
   return new URL(profileUrl, import.meta.url).href;
 };
-
-// 중간 매핑: [userNickname, { 추구미유형, 캐릭터 }] 쌍 배열
-const allUsers = [...LAST_RANKING_LIST.value, ...RANKING_LIST];
-const rewardEntries = allUsers.map(user => {
-  const level = getLevel(user.score);
-
-  const mapEntry = CHOOGOOMI_MAP.find(
-    item => item.choogoomiName === user.choogoomiName
-  );
-  return [
-    user.userNickname,
-    {
-      choogoomiType: mapEntry.userLevel[level].choogoomiType,
-      profile: new URL(mapEntry.userLevel[level].profile, import.meta.url).href,
-    },
-  ];
-});
-
-// choogoomiName만 추출 -> 'v-for'에 사용
-const choogoomiNames = [...new Set(allUsers.map(user => user.choogoomiName))];
-// 유형 이름 객체로 변환 (nickname -> 지출제로형) [DELETE]
-const choogoomiType = Object.fromEntries(
-  rewardEntries.map(([nickname, data]) => [nickname, data.choogoomiType])
-);
-// console.log(choogoomiType);
-
-// 프로필 이미지 객체로 변환 (nickname -> profile 이미지 경로)
-const choogoomiCharacter = Object.fromEntries(
-  rewardEntries.map(([nickname, data]) => [nickname, data.profile])
-);
-
-// 보상 매핑 객체 (A -> {1: "...", 2: "...", 3: "..."})
-const rewardMap = Object.fromEntries(
-  REWARD_LIST.map(item => [item.choogoomiName, item.rewards])
-);
 
 function handlePhoneSubmit(phoneNumber) {
   console.log('제출된 전화번호:', phoneNumber);


### PR DESCRIPTION
# 📌 랭킹 페이지 API 연결

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 기존의 더미 데이터를 제거하고 요청 후 받아오는 데이터를 보여주도록 구조를 수정했습니다.
- 상품 정보만 알려주는 rewardList.js의 choogoomiName을 렌더링 하기 편하게 텍스트로 수정하였습니다.
- 지난주의 상위 랭커 3명의 데이터 요청 API를 연결했습니다.
- 이번주의 실시간 랭킹 데이터 요청 API를 연결했습니다.
- 이전 랭킹과 비교해서 아이콘, 텍스트 스타일 변화를 적용하였습니다.
- 요청이 완료되기 전까지 로딩 화면을 적용했습니다.

---

## ✅ 체크리스트

- [x] 데이터를 성공적으로 가져오는지 확인했습니다.
- [x] 요청 중에 로딩 컴포넌트가 제대로 보여지는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->
<img width="393" height="956" alt="스크린샷 2025-08-04 오후 1 03 34" src="https://github.com/user-attachments/assets/83212c9a-1dc3-4106-890d-6839365ccbee" />

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
랭킹이 올랐으면 빨간색, 내려갔으면 파란색, 그대로이면 limegreen-900을 적용했습니다.
랭킹 페이지에 들어서면 랭킹 업데이트 요청 후, 데이터를 가져오는 동안 로딩 화면을 적용했습니다~

