### PR TITLE
feat : 매칭 히스토리 페이지 api 연결

### DIFF
--- a/src/views/mypage/MyPageRecordView.vue
+++ b/src/views/mypage/MyPageRecordView.vue
@@ -45,22 +45,15 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, onMounted, reactive, ref } from 'vue';
 
+import axiosInstance from '@/api/axios';
 import back from '@/assets/img/icons/system/system_back.png';
 import TopNavigation from '@/components/TopNavigation.vue';
 
 import RecordCard from './components/RecordCard.vue';
 
-const RECORDS = [
-  { id: 1, ranking: 15, score: 100, startDate: '2025-07-28' },
-  { id: 2, ranking: 13, score: 150, startDate: '2025-08-04' },
-  { id: 3, ranking: 12, score: 200, startDate: '2025-08-11' },
-  { id: 4, ranking: 11, score: 240, startDate: '2025-08-18' },
-  { id: 5, ranking: 10, score: 250, startDate: '2025-08-25' },
-  { id: 6, ranking: 9, score: 270, startDate: '2025-09-01' },
-  { id: 7, ranking: 8, score: 300, startDate: '2025-09-08' },
-];
+const RECORDS = reactive([]);
 
 const page = ref(0); //현재 페이지 번호
 const pageSize = 4; //한 페이지에 표시할 카드 개수
@@ -97,4 +90,15 @@ function prevPage() {
 function nextPage() {
   if (canGoNext.value) page.value--;
 }
+
+onMounted(async () => {
+  try {
+    const { data } = await axiosInstance.get('api/ranking/history');
+    console.log(data);
+    Object.assign(RECORDS, data);
+    console.log(RECORDS);
+  } catch (error) {
+    console.log(error);
+  }
+});
 </script>

--- a/src/views/mypage/MyPageRecordView.vue
+++ b/src/views/mypage/MyPageRecordView.vue
@@ -59,18 +59,18 @@ import RecordCard from './components/RecordCard.vue';
 const RECORDS = reactive([]);
 
 const page = ref(0); //현재 페이지 번호
-const pageSize = 4; //한 페이지에 표시할 카드 개수
+const PAGE_SIZE = 4; //한 페이지에 표시할 카드 개수
 
 //총 페이지수
-const totalPages = computed(() => Math.ceil(RECORDS.length / pageSize));
+const totalPages = computed(() => Math.ceil(RECORDS.length / PAGE_SIZE));
 
 // 화면에 보여줄 데이터 추출
 const pagedRecords = computed(() => {
   // 전체 개수
 
   // 4개씩 슬라이스
-  const start = page.value * pageSize;
-  const end = start + pageSize;
+  const start = page.value * PAGE_SIZE;
+  const end = start + PAGE_SIZE;
   return RECORDS.slice(start, end);
 });
 

--- a/src/views/mypage/components/RecordCard.vue
+++ b/src/views/mypage/components/RecordCard.vue
@@ -13,9 +13,7 @@
   </button>
 </template>
 <script setup>
-import { computed, onMounted, ref } from 'vue';
-
-import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
+import { computed } from 'vue';
 
 const { choogoomiImage, roundNumber, startDate, ranking, score } = defineProps({
   choogoomiImage: { type: String, required: true },

--- a/src/views/mypage/components/RecordCard.vue
+++ b/src/views/mypage/components/RecordCard.vue
@@ -6,20 +6,22 @@
       {{ formattedDateRange }}
     </div>
     <div class="flex my-1 mx-3 justify-center items-center">
-      <img class="h-[80%]" :src="character_savings" alt="" />
+      <img class="h-[80%]" :src="choogoomiImage" alt="" />
     </div>
-    <div class="text-limegreen-800 text-normal">{{ rank }}위</div>
+    <div class="text-limegreen-800 text-normal">{{ ranking }}위</div>
     <div class="text-gray-300 text-sm my-1">{{ score }}점</div>
   </button>
 </template>
 <script setup>
-import { computed } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
-import character_savings from '@/assets/img/characters/character_savings.png';
+import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
 
-const { startDate, rank, score } = defineProps({
-  startDate: { type: String, required: true },
-  rank: { type: Number, required: true },
+const { choogoomiImage, roundNumber, startDate, ranking, score } = defineProps({
+  choogoomiImage: { type: String, required: true },
+  roundNumber: { type: Number, required: true },
+  startDate: { type: Number, required: true },
+  ranking: { type: Number, required: true },
   score: { type: Number, required: true },
 });
 

--- a/src/views/mypage/components/RecordCard.vue
+++ b/src/views/mypage/components/RecordCard.vue
@@ -1,11 +1,11 @@
 <template>
   <button
-    class="flex flex-col py-1 justify-center items-center bg-white border-3 border-limegreen-500 rounded-[10px] shadow"
+    class="flex flex-col w-30 py-1 justify-center items-center bg-white border-3 border-limegreen-500 rounded-[10px] shadow"
   >
     <div class="text-limegreen-800 text-sm mt-1 whitespace-pre-line">
       {{ formattedDateRange }}
     </div>
-    <div class="flex my-1 mx-3 justify-center items-center">
+    <div class="flex h-30 justify-center items-center">
       <img class="h-[80%]" :src="choogoomiImage" alt="" />
     </div>
     <div class="text-limegreen-800 text-normal">{{ ranking }}위</div>


### PR DESCRIPTION
# 📌 매칭 히스토리 페이지 api 연결

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 매칭 히스토리 페이지에서 지금까지의 매칭 기록을 볼 수 있습니다.
- 매칭 당시의 점수, 랭킹, 추구미를 볼 수 있습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 최신순으로 매칭 기록이 뜨는지 확인했습니다.
- [x] 매칭 시작/끝 날짜가 제대로 계산되는지 확인했습니다

---

## 📷 스크린샷(선택)
<img width="243" height="435" alt="매칭기록1" src="https://github.com/user-attachments/assets/bbfb8eed-54a2-4d42-8c55-f9d94dcd4d73" />
<img width="243" height="435" alt="매칭기록2" src="https://github.com/user-attachments/assets/2b9050c2-3cc4-4e85-aff5-bd8b56c81b0d" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항
지금은 데이터가 임의로 들어가있어서 매칭 기간의 날짜가 겹치지만, 실제로는 겹치지 않을거라고 하십니다!
<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
