### PR TITLE
feat: 설문조사 API 연결 및 첫 로그인 시 설문조사로 유도

### DIFF
--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -9,3 +9,15 @@ export const updateChoogooMi = async choogooMi => {
     throw new Error('추구미 선택 실패');
   }
 };
+
+export const submitSurvey = async surveyAnswers => {
+  try {
+    const response = await axiosInstance.post(
+      'api/survey/submit',
+      surveyAnswers
+    );
+    return response.data;
+  } catch {
+    throw new Error('설문 제출 실패');
+  }
+};

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 
+import { userInfo } from '@/api/authApi';
 import { useAuthStore } from '@/stores/authStore';
 import AssetConnectView from '@/views/asset/AssetConnectView.vue';
 import AssetSelectView from '@/views/asset/AssetSelectView.vue';
@@ -27,6 +28,20 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView,
+      beforeEnter: async (to, from, next) => {
+        try {
+          const userData = await userInfo();
+          // 츄고미 미선택 시 설문조사로 리다이렉트
+          if (userData.choogooMi === 'O') {
+            return next('/survey');
+          }
+          next();
+        } catch (error) {
+          console.error('사용자 정보 조회 실패:', error);
+          // 에러 발생 시 이전 페이지로 리디렉트
+          next(false);
+        }
+      },
     },
     {
       path: '/transaction/:bankId/:accountNum/:accountName',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -31,7 +31,7 @@ const router = createRouter({
       beforeEnter: async (to, from, next) => {
         try {
           const userData = await userInfo();
-          // 츄고미 미선택 시 설문조사로 리다이렉트
+          // 추구미 미선택 시 설문조사로 리다이렉트
           if (userData.choogooMi === 'O') {
             return next('/survey');
           }

--- a/src/views/asset/AssetConnectView.vue
+++ b/src/views/asset/AssetConnectView.vue
@@ -156,7 +156,7 @@ const connectAsset = async () => {
 // 모달 닫기 핸들러
 const handleModalClose = () => {
   isModalOpen.value = false;
-  // 성공한 경우에만 홈으로 이동
+  // 성공한 경우에만 추구미 선택 페이지로 이동
   if (modalType.value === true) {
     router.push({ name: 'choogoomi' });
   }

--- a/src/views/asset/AssetConnectView.vue
+++ b/src/views/asset/AssetConnectView.vue
@@ -158,7 +158,7 @@ const handleModalClose = () => {
   isModalOpen.value = false;
   // 성공한 경우에만 홈으로 이동
   if (modalType.value === true) {
-    router.push({ name: 'home' });
+    router.push({ name: 'choogoomi' });
   }
 };
 

--- a/src/views/signup/components/survey/SurveyView.vue
+++ b/src/views/signup/components/survey/SurveyView.vue
@@ -11,20 +11,33 @@
       v-if="currentStep === 2"
       @next="handleSurveyTwoComplete"
     />
+    <AlertModal
+      v-if="isSuccessModalOpen"
+      title="설문 제출 완료"
+      message="설문 제출이 완료되었습니다."
+      @close="handleModalClose"
+    />
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+import { submitSurvey } from '@/api/userApi';
+import AlertModal from '@/components/AlertModal.vue';
 
 import SurveyOneComponent from './SurveyOneComponent.vue';
 import SurveyTwoComponent from './SurveyTwoComponent.vue';
 
+const router = useRouter();
 // 현재 설문 단계 (1: 첫 번째 설문, 2: 두 번째 설문)
 const currentStep = ref(1);
 
 // 설문 데이터를 저장할 평면 배열 [설문1답변1, 설문1답변2, ..., 설문2답변1, 설문2답변2, ...] (총 14개)
 const surveyAnswers = ref([]);
+
+const isSuccessModalOpen = ref(false);
 
 // 설문 1 완료 처리
 const handleSurveyOneComplete = surveyOneAnswers => {
@@ -53,8 +66,15 @@ const convertToRequestData = () => {
   };
 };
 
-const sendSurveyData = () => {
+const sendSurveyData = async () => {
   const requestData = convertToRequestData();
-  console.log('요청 데이터:', requestData);
+
+  await submitSurvey(requestData);
+  isSuccessModalOpen.value = true;
+};
+
+const handleModalClose = () => {
+  isSuccessModalOpen.value = false;
+  router.push('/asset/select');
 };
 </script>


### PR DESCRIPTION
# 📌 설문조사 API 연결 및 첫 로그인 시 유도

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 설문조사에서의 답변 내용들을 API에 담아서 요청해서 저장하도록 했습니다.
- 첫 로그인 시(choogooMi='O')인 경우에 설문조사 페이지로 리디렉션 하도록 했습니다.
- 설문조사 완료 후 자산 연동 페이지로 이동합니다.
- 자산연동 후 추구 유형 선택 페이지로 이동하고 선택 완료 후에는 메인화면으로 돌아오게 됩니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 설문조사 데이터, 선택한 유형으로 데이터가 저장되는지 확인했습니다.


---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->

로그인 후 입력해야 하는 절차중 가장 마지막인 추구 유형을 기준으로 했습니다.
유형이 선택이 되지 않았을 때(`choogooMi==='O'`)`/home`에 진입하면 `/survey`로 리디렉션으로 설정했습니다! (혹시 더 좋은 방법이나 의견 있으시면 말씀해주세요!)

설문조사 제출하는 api를 `userApi.js`에 분리해놨습니다. 이후에 리팩토링 하게 된다면 auth와 user api 분리를 해도 좋을 것 같습니다!