### PR TITLE
feat : 매칭 기록 상세 모달창 구현

### DIFF
--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -1,0 +1,13 @@
+import axiosInstance from './axios';
+
+//roundNumber로 매칭 상세 기록 가져오기
+export const getResultByRound = async roundNumber => {
+  try {
+    const { data } = await axiosInstance.get(
+      `/api/matching/history?roundNumber=${roundNumber}`
+    );
+    return data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/api/ranking.js
+++ b/src/api/ranking.js
@@ -26,3 +26,13 @@ export const updateRankingData = async () => {
     return false;
   }
 };
+
+//주별 랭킹, 점수, 추구미 정보 리스트 가져오기
+export const getRankingHistory = async () => {
+  try {
+    const { data } = await axiosInstance.get('api/ranking/history');
+    return data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -5,7 +5,7 @@
     >
       <!--지난주 매칭 결과-->
       <div class="flex flex-col gap-0.5 w-full mt-1">
-        <div class="text-limegreen-900 text-lg">지난주 매칭 결과</div>
+        <div class="text-limegreen-900 text-lg">{{ title }}</div>
         <div class="bg-ivory flex rounded-2xl p-5">
           <div class="flex gap-6 text-sm text-center items-center">
             <div>
@@ -39,7 +39,25 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { onMounted, ref } from 'vue';
+
+import axiosInstance from '@/api/axios';
 
 import MissionListCard from './MissionListCard.vue';
+
+const props = defineProps({
+  roundNumber: { type: Number, required: true },
+  title: { type: String, required: true },
+});
+
+onMounted(async () => {
+  try {
+    const { data } = await axiosInstance.get(
+      `/api/matching/history?roundNumber=${props.roundNumber}`
+    );
+    console.log(data);
+  } catch {
+    console.log(error);
+  }
+});
 </script>

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -35,12 +35,14 @@
       <div class="flex flex-col w-full gap-0.5">
         <div class="text-limegreen-900 text-lg">미션 목록</div>
         <div class="flex flex-col gap-2 text-sm">
+          <!--나의 미션-->
           <MissionListCard
             v-for="(myMission, index) in matchingResult.myMissionProgressList"
             :key="myMission.missionId"
             :index="index"
             :missions="myMission"
           />
+          <!--상대방 미션-->
           <MissionListCard
             v-for="(
               opponentMission, index
@@ -64,7 +66,7 @@
 <script setup>
 import { onMounted, reactive, ref } from 'vue';
 
-import axiosInstance from '@/api/axios';
+import { getResultByRound } from '@/api/matchingApi';
 
 import MissionListCard from './MissionListCard.vue';
 
@@ -84,10 +86,8 @@ const isLoaded = ref(false);
 
 onMounted(async () => {
   try {
-    const { data } = await axiosInstance.get(
-      `/api/matching/history?roundNumber=${props.roundNumber}`
-    );
-    Object.assign(matchingResult, data);
+    const result = await getResultByRound(props.roundNumber);
+    Object.assign(matchingResult, result);
     isLoaded.value = true;
   } catch (error) {
     console.log(error);

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -10,7 +10,9 @@
       <div class="flex flex-col gap-0.5 w-full mt-1">
         <div class="text-limegreen-900 text-lg">{{ title }}</div>
         <div class="bg-ivory flex rounded-2xl p-5 justify-center">
-          <div class="flex gap-6 text-sm text-center items-center">
+          <div
+            class="flex w-full text-sm text-center justify-around items-center"
+          >
             <div>
               <div class="text-limegreen-900">
                 {{ matchingResult.myMissionProgressList[0].userNickname }}

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -9,7 +9,7 @@
       <!--지난주 매칭 결과-->
       <div class="flex flex-col gap-0.5 w-full mt-1">
         <div class="text-limegreen-900 text-lg">{{ title }}</div>
-        <div class="bg-ivory flex rounded-2xl p-5">
+        <div class="bg-ivory flex rounded-2xl p-5 justify-center">
           <div class="flex gap-6 text-sm text-center items-center">
             <div>
               <div class="text-limegreen-900">

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="fixed inset-0 flex items-center justify-center bg-black/70 z-20">
+  <div
+    v-if="isLoaded"
+    class="fixed inset-0 flex items-center justify-center bg-black/70 z-20"
+  >
     <div
       class="flex flex-col gap-4 bg-limegreen-500 rounded-4xl p-5 items-center"
     >
@@ -9,13 +12,19 @@
         <div class="bg-ivory flex rounded-2xl p-5">
           <div class="flex gap-6 text-sm text-center items-center">
             <div>
-              <div class="text-limegreen-900">카카오대학교라이언</div>
-              <div class="text-green">50점</div>
+              <div class="text-limegreen-900">
+                {{ matchingResult.myMissionProgressList[0].userNickname }}
+              </div>
+              <div class="text-green">{{ matchingResult.myTotalScore }}점</div>
             </div>
             <div class="text-limegreen-900 text-lg">VS</div>
             <div>
-              <div class="text-limegreen-900">카카오대학교어피치</div>
-              <div class="text-green">20점</div>
+              <div class="text-limegreen-900">
+                {{ matchingResult.opponentMissionProgressList[0].userNickname }}
+              </div>
+              <div class="text-green">
+                {{ matchingResult.opponentTotalScore }}점
+              </div>
             </div>
           </div>
         </div>
@@ -39,7 +48,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 
 import axiosInstance from '@/api/axios';
 
@@ -50,13 +59,23 @@ const props = defineProps({
   title: { type: String, required: true },
 });
 
+const matchingResult = reactive({
+  myMissionProgressList: [],
+  opponentMissionProgressList: [],
+  myTotalScore: 0,
+  opponentTotalScore: 0,
+});
+
+const isLoaded = ref(false);
+
 onMounted(async () => {
   try {
     const { data } = await axiosInstance.get(
       `/api/matching/history?roundNumber=${props.roundNumber}`
     );
-    console.log(data);
-  } catch {
+    Object.assign(matchingResult, data);
+    isLoaded.value = true;
+  } catch (error) {
     console.log(error);
   }
 });

--- a/src/views/matching/components/MatchingResultModal.vue
+++ b/src/views/matching/components/MatchingResultModal.vue
@@ -33,8 +33,20 @@
       <div class="flex flex-col w-full gap-0.5">
         <div class="text-limegreen-900 text-lg">미션 목록</div>
         <div class="flex flex-col gap-2 text-sm">
-          <MissionListCard />
-          <MissionListCard />
+          <MissionListCard
+            v-for="(myMission, index) in matchingResult.myMissionProgressList"
+            :key="myMission.missionId"
+            :index="index"
+            :missions="myMission"
+          />
+          <MissionListCard
+            v-for="(
+              opponentMission, index
+            ) in matchingResult.opponentMissionProgressList"
+            :key="opponentMission.missionId"
+            :index="index"
+            :missions="opponentMission"
+          />
         </div>
       </div>
       <button

--- a/src/views/matching/components/MissionListCard.vue
+++ b/src/views/matching/components/MissionListCard.vue
@@ -20,7 +20,7 @@
             :class="[
               'text-sm',
               'mr-5',
-              isMissionCompleted ? 'text-' : 'text-gray-200',
+              isMissionCompleted ? 'text-' : 'text-gray-300',
             ]"
           >
             {{ missions.missionTitle }}
@@ -30,7 +30,7 @@
           :class="[
             'text-xs',
             'mr-1',
-            isMissionCompleted ? 'text-yellow' : 'text-gray-200',
+            isMissionCompleted ? 'text-yellow' : 'text-gray-300',
           ]"
         >
           {{ missions.score }}점

--- a/src/views/matching/components/MissionListCard.vue
+++ b/src/views/matching/components/MissionListCard.vue
@@ -2,7 +2,7 @@
   <div class="bg-ivory p-4 rounded-2xl">
     <!--닉네임-->
     <span class="bg-limegreen-100 text-green px-2 py-1 rounded-full text-sm">
-      카카오대학교라이언
+      {{ missions.userNickname }}
     </span>
     <!--미션목록-->
     <div class="flex flex-col mt-2 gap-2">
@@ -14,13 +14,20 @@
           <div
             class="bg-limegreen-500 rounded-lg w-5 h-5 justify-center text-center"
           >
-            1
+            {{ index + 1 }}
           </div>
-          <div class="text-sm text-green">공통 미션 : 지출 반성문 쓰기</div>
+          <div class="text-sm text-green">{{ missions.missionTitle }}</div>
         </div>
-        <div class="text-xs text-yellow mr-1">10점</div>
+        <div class="text-xs text-yellow mr-1">{{ missions.score }}점</div>
       </div>
     </div>
   </div>
 </template>
-<script></script>
+<script setup>
+const props = defineProps({
+  missions: { type: Object, required: true },
+  index: { type: Number, required: true },
+});
+
+console.log(props.missions);
+</script>

--- a/src/views/matching/components/MissionListCard.vue
+++ b/src/views/matching/components/MissionListCard.vue
@@ -16,17 +16,40 @@
           >
             {{ index + 1 }}
           </div>
-          <div class="text-sm text-green">{{ missions.missionTitle }}</div>
+          <div
+            :class="[
+              'text-sm',
+              'mr-5',
+              isMissionCompleted ? 'text-' : 'text-gray-200',
+            ]"
+          >
+            {{ missions.missionTitle }}
+          </div>
         </div>
-        <div class="text-xs text-yellow mr-1">{{ missions.score }}점</div>
+        <div
+          :class="[
+            'text-xs',
+            'mr-1',
+            isMissionCompleted ? 'text-yellow' : 'text-gray-200',
+          ]"
+        >
+          {{ missions.score }}점
+        </div>
       </div>
     </div>
   </div>
 </template>
 <script setup>
+import { computed } from 'vue';
+
 const props = defineProps({
   missions: { type: Object, required: true },
   index: { type: Number, required: true },
+});
+
+// 미션 완료 여부를 계산
+const isMissionCompleted = computed(() => {
+  return props.missions.missionScore === props.missions.score;
 });
 
 console.log(props.missions);

--- a/src/views/matching/components/MissionListCard.vue
+++ b/src/views/matching/components/MissionListCard.vue
@@ -51,6 +51,4 @@ const props = defineProps({
 const isMissionCompleted = computed(() => {
   return props.missions.missionScore === props.missions.score;
 });
-
-console.log(props.missions);
 </script>

--- a/src/views/mypage/MyPageRecordView.vue
+++ b/src/views/mypage/MyPageRecordView.vue
@@ -107,7 +107,6 @@ const pagedRecordsWithImages = computed(() =>
 onMounted(async () => {
   try {
     const { data } = await axiosInstance.get('api/ranking/history');
-    console.log(data);
     Object.assign(RECORDS, data);
   } catch (error) {
     console.log(error);

--- a/src/views/mypage/MyPageRecordView.vue
+++ b/src/views/mypage/MyPageRecordView.vue
@@ -49,7 +49,7 @@
 <script setup>
 import { computed, onMounted, reactive, ref } from 'vue';
 
-import axiosInstance from '@/api/axios';
+import { getRankingHistory } from '@/api/ranking';
 import back from '@/assets/img/icons/system/system_back.png';
 import TopNavigation from '@/components/TopNavigation.vue';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
@@ -106,8 +106,8 @@ const pagedRecordsWithImages = computed(() =>
 
 onMounted(async () => {
   try {
-    const { data } = await axiosInstance.get('api/ranking/history');
-    Object.assign(RECORDS, data);
+    const result = await getRankingHistory();
+    Object.assign(RECORDS, result);
   } catch (error) {
     console.log(error);
   }

--- a/src/views/mypage/components/RecordCard.vue
+++ b/src/views/mypage/components/RecordCard.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     class="flex flex-col w-30 py-1 justify-center items-center bg-white border-3 border-limegreen-500 rounded-[10px] shadow"
-    @click="openResultModal"
+    @click="handleModal"
   >
     <div class="text-limegreen-800 text-sm mt-1 whitespace-pre-line">
       {{ formattedDateRange }}
@@ -16,18 +16,13 @@
     v-if="isResultModal"
     :round-number="roundNumber"
     :title="formattedDateRange"
-    @close="isResultModal = false"
+    @close="handleModal"
   />
 </template>
 <script setup>
 import { computed, ref } from 'vue';
 
 import MatchingResultModal from '@/views/matching/components/MatchingResultModal.vue';
-
-const isResultModal = ref(false);
-const openResultModal = () => {
-  isResultModal.value = true;
-};
 
 const { choogoomiImage, roundNumber, startDate, ranking, score } = defineProps({
   choogoomiImage: { type: String, required: true },
@@ -36,6 +31,12 @@ const { choogoomiImage, roundNumber, startDate, ranking, score } = defineProps({
   ranking: { type: Number, required: true },
   score: { type: Number, required: true },
 });
+
+const isResultModal = ref(false);
+
+const handleModal = () => {
+  isResultModal.value = !isResultModal.value;
+};
 
 // 날짜 포맷 계산
 const formattedDateRange = computed(() => {

--- a/src/views/mypage/components/RecordCard.vue
+++ b/src/views/mypage/components/RecordCard.vue
@@ -1,6 +1,7 @@
 <template>
   <button
     class="flex flex-col w-30 py-1 justify-center items-center bg-white border-3 border-limegreen-500 rounded-[10px] shadow"
+    @click="openResultModal"
   >
     <div class="text-limegreen-800 text-sm mt-1 whitespace-pre-line">
       {{ formattedDateRange }}
@@ -11,9 +12,22 @@
     <div class="text-limegreen-800 text-normal">{{ ranking }}위</div>
     <div class="text-gray-300 text-sm my-1">{{ score }}점</div>
   </button>
+  <MatchingResultModal
+    v-if="isResultModal"
+    :round-number="roundNumber"
+    :title="formattedDateRange"
+    @close="isResultModal = false"
+  />
 </template>
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+
+import MatchingResultModal from '@/views/matching/components/MatchingResultModal.vue';
+
+const isResultModal = ref(false);
+const openResultModal = () => {
+  isResultModal.value = true;
+};
 
 const { choogoomiImage, roundNumber, startDate, ranking, score } = defineProps({
   choogoomiImage: { type: String, required: true },


### PR DESCRIPTION
# 📌 매칭 기록 상세 모달창

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 마이페이지->매칭 기록 페이지에서 카드를 클릭하면 해당 날짜의 매칭 상세 기록을 확인할 수 있습니다.
- 미션 목록과 완료 여부를 확인할 수 있습니다.
- 해당 기간의 총점을 확인할 수 있습니다.
- 미션 달성 여부에 따라 스타일을 다르게 반영하도록 했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 미션 목록, 총점 등 api가 잘 동작하는지 확인했습니다.
- [x] 미션 달성 여부에 따라 미션제목과 점수 스타일이 달라지는지 확인했습니다.

---

## 📷 스크린샷(선택)
<img width="270" height="480" alt="기록 상세" src="https://github.com/user-attachments/assets/89da7619-ba5c-4897-b853-6e33cfa27d3d" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항
매칭 기록을 클릭했을 때 미션 목록 api를 불러온 뒤 모달창을 띄우게 해놔서 모달창이 뜨는데까지 시간이 조금 걸립니다..
이걸 해결할 수 있는 좋은 방법이 있다면 말씀해주세요!
<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
