### PR TITLE
fix: 로그아웃 시 로그인 화면으로 이동이 아닌 메인 화면에 머무는 오류 수정

### DIFF
--- a/src/views/mypage/MyPageView.vue
+++ b/src/views/mypage/MyPageView.vue
@@ -127,6 +127,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
 import router from '@/router';
+import { useAuthStore } from '@/stores/authStore';
 import { isEditableDay } from '@/utils/dateUtils';
 import { getLevel, LEVEL_THRESHOLDS } from '@/utils/levelUtils';
 
@@ -137,6 +138,8 @@ const showChoogoomiEditModal = ref(false);
 
 const choogoomiImage = ref('');
 const userLevel = ref(0);
+
+const authStore = useAuthStore();
 
 const userInfo = reactive({
   choogoomiName: '',
@@ -149,7 +152,7 @@ const userInfo = reactive({
 const isEditable = isEditableDay();
 
 const logout = () => {
-  localStorage.clear();
+  authStore.clearAuth();
   router.push('/login');
 };
 


### PR DESCRIPTION
# 📌 로그아웃 오류 수정

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 로그아웃 시에 localStorage의 값만 제거 되어 pinia에는 값이 있어서 login이 아닌 메인 화면에 머무는 오류를 발견했습니다.
- pinia에 저장된 값을 삭제하고 LocalStorage 값도 삭제하도록 수정했습니다.

---

## ✅ 체크리스트

- [x] 로그아웃 시 login 화면으로 이동되는지 확인했습니다.
- [x] 로그아웃 시 localStorage 뿐만 아니라 pinia에도 데이터가 삭제되는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
