### PR TITLE
feat: 자산 리포트 API 연결

### DIFF
--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -21,3 +21,12 @@ export const submitSurvey = async surveyAnswers => {
     throw new Error('설문 제출 실패');
   }
 };
+
+export const createReport = async () => {
+  try {
+    const response = await axiosInstance.post('api/report/create');
+    return response.data;
+  } catch {
+    throw new Error('리포트 생성 실패');
+  }
+};

--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -30,3 +30,12 @@ export const createReport = async () => {
     throw new Error('리포트 생성 실패');
   }
 };
+
+export const fetchUserData = async () => {
+  try {
+    const response = await axiosInstance.get('api/users/main-profile');
+    return response.data;
+  } catch {
+    throw new Error('유저 데이터 조회 실패');
+  }
+};

--- a/src/views/asset/report/components/AnalysisCard.vue
+++ b/src/views/asset/report/components/AnalysisCard.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script setup>
-import { defineProps } from 'vue';
+import { computed, defineProps } from 'vue';
 
 // Props 정의
 const props = defineProps({
@@ -123,8 +123,14 @@ const props = defineProps({
   },
 });
 
-const { image, name, summary } = props.characterData;
-const { percentage, categories } = props.chartData;
+// 차트 데이터 computed로 반응성 유지
+const percentage = computed(() => props.chartData.percentage);
+const categories = computed(() => props.chartData.categories);
+
+// 캐릭터 데이터 computed로 반응성 유지
+const image = computed(() => props.characterData.image);
+const name = computed(() => props.characterData.name);
+const summary = computed(() => props.characterData.summary);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# 📌 리포트 생성 API 연결

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 레포트 생성 API 연결을 했습니다.
- 유저의 닉네임, 총 자산을 가져오도록 수정했습니다.

---

## ✅ 체크리스트

- [x] 요청과 반환된 데이터가 잘 표시되는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->
<img width="394" height="960" alt="스크린샷 2025-08-06 오전 10 53 36" src="https://github.com/user-attachments/assets/54b02ddd-6484-4a87-9e9b-9e7559481a75" />

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->

기존의 방식은 AnalysisCard.vue에서 전달받은 프롭스를 구조분해할당으로 한번 변수에 할당시켜서 렌더링 하는 방식이였습니다.
상수값이여서 문제가 없었지만 구조분해할당 시에는 초기값이 변수에 할당된다고 합니다. 그래서 `computed로 반응성을 유지하도록 수정`했습니다. (toRefs()를 적용하려고 했는데 이후에 리팩토링 시간이 있다면 그때 좀 더 알아보고 적용해봐야 할 거 같습니다!)

---

아직 리포트 생성 api가 설문조사를 바탕으로만 진행되는 것으로 알고 있습니다.
오늘이나 내일쯤 api가 보완이 되면 더 정확한 데이터가 보여질 것 같습니다!
+ 아직 추천 받는 유형은 정확하지 않고, 자산 데이터는 전달받지 못해서 이후에 작업할 것 같습니다!