### PR TITLE
feat : 홈,마이페이지 최근 성적 계산 기능 추가

### DIFF
--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -23,3 +23,15 @@ export const getResultByRound = async roundNumber => {
     console.log(error);
   }
 };
+
+//매칭결과 히스토리 가져오기 (n승 n무 n패 표시용)
+export const getMatchingHistory = async () => {
+  try {
+    const { data } = await axiosInstance.get(
+      '/api/users/matching/result/history'
+    );
+    return data;
+  } catch {
+    throw new Error('매칭결과 히스토리 가져오기 실패');
+  }
+};

--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -30,6 +30,71 @@ export const getMatchingHistory = async () => {
     const { data } = await axiosInstance.get(
       '/api/users/matching/result/history'
     );
+
+    //mock데이터 (실제 데이터가 생기면 삭제 후 api 호출 코드의 주석을 제거하면 됨)
+    const data2 = [
+      {
+        roundNumber: 1,
+        startDate: '2025-06-06T00:00:00.000+09:00',
+        endDate: '2025-06-12T00:00:00.000+09:00',
+        matchingResult: 'WIN',
+      },
+      {
+        roundNumber: 2,
+        startDate: '2025-06-13T00:00:00.000+09:00',
+        endDate: '2025-06-19T00:00:00.000+09:00',
+        matchingResult: 'LOSE',
+      },
+      {
+        roundNumber: 3,
+        startDate: '2025-06-20T00:00:00.000+09:00',
+        endDate: '2025-06-26T00:00:00.000+09:00',
+        matchingResult: 'DRAW',
+      },
+      {
+        roundNumber: 4,
+        startDate: '2025-06-27T00:00:00.000+09:00',
+        endDate: '2025-07-03T00:00:00.000+09:00',
+        matchingResult: 'WIN',
+      },
+      {
+        roundNumber: 5,
+        startDate: '2025-07-04T00:00:00.000+09:00',
+        endDate: '2025-07-10T00:00:00.000+09:00',
+        matchingResult: 'WIN',
+      },
+      {
+        roundNumber: 6,
+        startDate: '2025-07-11T00:00:00.000+09:00',
+        endDate: '2025-07-17T00:00:00.000+09:00',
+        matchingResult: 'LOSE',
+      },
+      {
+        roundNumber: 7,
+        startDate: '2025-07-18T00:00:00.000+09:00',
+        endDate: '2025-07-24T00:00:00.000+09:00',
+        matchingResult: 'WIN',
+      },
+      {
+        roundNumber: 8,
+        startDate: '2025-07-25T00:00:00.000+09:00',
+        endDate: '2025-07-31T00:00:00.000+09:00',
+        matchingResult: 'DRAW',
+      },
+      {
+        roundNumber: 9,
+        startDate: '2025-08-01T00:00:00.000+09:00',
+        endDate: '2025-08-07T00:00:00.000+09:00',
+        matchingResult: 'LOSE',
+      },
+      {
+        roundNumber: 10,
+        startDate: '2025-08-08T00:00:00.000+09:00',
+        endDate: '2025-08-14T00:00:00.000+09:00',
+        matchingResult: 'WIN',
+      },
+    ];
+
     return data;
   } catch {
     throw new Error('매칭결과 히스토리 가져오기 실패');

--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -27,12 +27,12 @@ export const getResultByRound = async roundNumber => {
 //매칭결과 히스토리 가져오기 (n승 n무 n패 표시용)
 export const getMatchingHistory = async () => {
   try {
-    const { data } = await axiosInstance.get(
+    /* const { data } = await axiosInstance.get(
       '/api/users/matching/result/history'
-    );
+    ); */
 
     //mock데이터 (실제 데이터가 생기면 삭제 후 api 호출 코드의 주석을 제거하면 됨)
-    const data2 = [
+    const data = [
       {
         roundNumber: 1,
         startDate: '2025-06-06T00:00:00.000+09:00',

--- a/src/utils/matchingUtils.js
+++ b/src/utils/matchingUtils.js
@@ -2,13 +2,13 @@ import { getMatchingHistory } from '@/api/matchingApi';
 
 //n승 n무 n패 계산
 export async function getMatchingRecordStats() {
-  const RECORDS = await getMatchingHistory();
+  const records = await getMatchingHistory();
 
   let win = 0,
     draw = 0,
     lose = 0;
 
-  for (const record of RECORDS) {
+  for (const record of records) {
     if (record.matchingResult === 'WIN') {
       win++;
     } else if (record.matchingResult === 'DRAW') {

--- a/src/utils/matchingUtils.js
+++ b/src/utils/matchingUtils.js
@@ -1,0 +1,22 @@
+import { getMatchingHistory } from '@/api/matchingApi';
+
+//n승 n무 n패 계산
+export async function getMatchingRecordStats() {
+  const RECORDS = await getMatchingHistory();
+
+  let win = 0,
+    draw = 0,
+    lose = 0;
+
+  for (const record of RECORDS) {
+    if (record.matchingResult === 'WIN') {
+      win++;
+    } else if (record.matchingResult === 'DRAW') {
+      draw++;
+    } else if (record.matchingResult === 'LOSE') {
+      lose++;
+    }
+  }
+
+  return { win, draw, lose };
+}

--- a/src/views/home/HomeView.vue
+++ b/src/views/home/HomeView.vue
@@ -58,7 +58,10 @@
             <div>
               <span class="text-[14px] text-limegreen-700">최근 성적</span
               ><br />
-              <span class="text-[17px] text-green">3승 2패</span>
+              <span class="text-[17px] text-green"
+                >{{ matchingRecord.win }}승 {{ matchingRecord.draw }}무
+                {{ matchingRecord.lose }}패</span
+              >
             </div>
           </div>
         </div>
@@ -162,6 +165,7 @@ import TopNavigation from '@/components/TopNavigation.vue';
 import { BANK_LIST } from '@/constants/bankList';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
 import { getLevel, LEVEL_THRESHOLDS } from '@/utils/levelUtils';
+import { getMatchingRecordStats } from '@/utils/matchingUtils';
 
 const router = useRouter();
 const isLoading = ref(true);
@@ -171,6 +175,8 @@ const USER_PROFILE = ref({}); // 프로필 정보
 // 추구미 유형 정보 - 추구미 유형명, 캐릭터
 const choogoomi = ref({});
 const choogoomiImage = ref(''); // 추구미 캐릭터 이미지 URL
+
+const matchingRecord = ref({}); //승패 데이터
 
 // 은행 ID로 은행 정보를 찾아 반환하는 함수
 const getBankInfo = bankId =>
@@ -239,6 +245,9 @@ onMounted(async () => {
       choogoomi.value.character,
       import.meta.url
     ).href;
+
+    //승패 기록 가져오기
+    matchingRecord.value = await getMatchingRecordStats();
 
     // 레벨 업 여부에 따라 보상 모달 표시 여부 결정
     showModal.value = USER_PROFILE.value.isLevelUp;

--- a/src/views/mypage/MyPageView.vue
+++ b/src/views/mypage/MyPageView.vue
@@ -73,7 +73,8 @@
           <div class="flex flex-col gap-1">
             <div class="text-limegreen-700">최근 성적</div>
             <div class="text-green">
-              {{ userInfo.userWin }}승 {{ userInfo.userLose }}패
+              {{ matchingRecord.win }}승 {{ matchingRecord.draw }}무
+              {{ matchingRecord.lose }}패
             </div>
           </div>
         </div>
@@ -130,17 +131,21 @@ import router from '@/router';
 import { useAuthStore } from '@/stores/authStore';
 import { isEditableDay } from '@/utils/dateUtils';
 import { getLevel, LEVEL_THRESHOLDS } from '@/utils/levelUtils';
+import { getMatchingRecordStats } from '@/utils/matchingUtils';
 
 import MyPageBtn from './components/MyPageBtn.vue';
 
+//모달창 상태 관리
 const showModal = ref(false);
 const showChoogoomiEditModal = ref(false);
 
+//추구미 이미지와 레벨 저장
 const choogoomiImage = ref('');
 const userLevel = ref(0);
 
 const authStore = useAuthStore();
 
+//api로 받아온 유저정보 저장
 const userInfo = reactive({
   choogoomiName: '',
   nickname: '',
@@ -149,6 +154,10 @@ const userInfo = reactive({
   isLevelUp: false,
 });
 
+//승패 겨로가 저장
+const matchingRecord = ref({});
+
+//추구미 수정 가능한 날인지
 const isEditable = isEditableDay();
 
 const logout = () => {
@@ -181,6 +190,9 @@ onMounted(async () => {
     userInfo.userScore = data.userScore;
     userInfo.userRanking = data.userRanking;
     userInfo.isLevelUp = data.isLevelUp;
+
+    //승패 기록 가져오기
+    matchingRecord.value = await getMatchingRecordStats();
   } catch (error) {
     console.error('프로필 정보 불러오기 실패');
   }

--- a/src/views/mypage/MyPageView.vue
+++ b/src/views/mypage/MyPageView.vue
@@ -154,7 +154,7 @@ const userInfo = reactive({
   isLevelUp: false,
 });
 
-//승패 겨로가 저장
+//승패 결과 저장
 const matchingRecord = ref({});
 
 //추구미 수정 가능한 날인지


### PR DESCRIPTION
# 📌 홈,마이페이지 승패 계산 기능 추가

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 홈과 마이페이지에 최근 성적을 계산해 반영하도록 했습니다.
- api 연동 후 승,무,패 횟수를 계산하도록 했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] api가 정상적으로 호출되는지 확인했습니다.
- [x] 승패 계산 함수가 제대로 동작하는지 확인했습니다.
- [x] 각 페이지에 최근 성적이 잘 반영되는지 확인했습니다.

---

## 📷 스크린샷(선택)
<img width="243" height="436" alt="localhost_5173_mypage(노트북)" src="https://github.com/user-attachments/assets/b29ccd53-5535-4832-9834-02d5ff16afba" />
<img width="243" height="436" alt="localhost_5173_mypage(노트북) (1)" src="https://github.com/user-attachments/assets/11920d3b-844e-4954-8caf-4caac542a0bd" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항
지금은 api를 호출했을 때 받아오는 데이터가 비어있어서 mock 데이터를 임시로 넣어놨습니다!
추후에 실제 데이터가 생기면 mock 데이터를 지우면 될 것 같습니다!
<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
