### PR TITLE
feat: 매칭페이지 미션 api 연동

### DIFF
--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -37,3 +37,17 @@ export const validateWriteMission = async missionId => {
     throw error;
   }
 };
+
+// 퀴즈 미션 인증 요청
+export const validateQuizMission = async (missionId, score) => {
+  try {
+    const response = await axiosInstance.put(
+      '/api/matching/missions/validate/4',
+      { missionId, score }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('퀴즈 미션 인증 요청 실패:', error);
+    throw error;
+  }
+};

--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -24,7 +24,6 @@ export const getResultByRound = async roundNumber => {
   }
 };
 
-
 // 글쓰기 미션 인증 요청
 export const validateWriteMission = async missionId => {
   try {
@@ -50,6 +49,8 @@ export const validateQuizMission = async (missionId, score) => {
   } catch (error) {
     console.error('퀴즈 미션 인증 요청 실패:', error);
     throw error;
+  }
+};
 
 //매칭결과 히스토리 가져오기 (n승 n무 n패 표시용)
 export const getMatchingHistory = async () => {

--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -23,3 +23,17 @@ export const getResultByRound = async roundNumber => {
     console.log(error);
   }
 };
+
+// 글쓰기 미션 인증 요청
+export const validateWriteMission = async missionId => {
+  try {
+    const response = await axiosInstance.put(
+      `/api/matching/missions/validate/3`,
+      { missionId }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('미션 인증 요청 실패:', error);
+    throw error;
+  }
+};

--- a/src/stores/choogoomiStore.js
+++ b/src/stores/choogoomiStore.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia';
+
+export const useChoogoomiStore = defineStore('choogoomi', {
+  state: () => ({
+    choogoomiType: '',
+  }),
+  actions: {
+    setChoogoomiType(type) {
+      this.choogoomiType = type;
+    },
+  },
+});

--- a/src/views/home/HomeView.vue
+++ b/src/views/home/HomeView.vue
@@ -158,7 +158,10 @@ import RewardModal from '@/components/RewardModal.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 import { BANK_LIST } from '@/constants/bankList';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
+import { useChoogoomiStore } from '@/stores/choogoomiStore';
 import { getLevel } from '@/utils/levelUtils';
+
+const choogoomiStore = useChoogoomiStore(); // 추구미 유형 저장
 
 const router = useRouter();
 const isLoading = ref(true);
@@ -195,6 +198,8 @@ onMounted(async () => {
     choogoomi.value = CHOOGOOMI_MAP.find(
       item => item.choogoomiName === USER_PROFILE.value.choogooMi
     ).userLevel[userLevel.value];
+
+    choogoomiStore.setChoogoomiType(choogoomi.value.choogoomiType);
 
     // 추구미 캐릭터 이미지 URL
     choogoomiImage.value = new URL(

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -225,9 +225,10 @@ console.log(choogoomiStore.choogoomiType);
 
 // 클릭(인증) 가능한 미션인지 확인
 //  -> 미션 타입 & 이미 수행했는지 확인
-const isClickableMission = mission =>
+const isClickableMission = mission => {
   ['TEXT_INPUT', 'QUIZ'].includes(mission.missionType) &&
-  mission.score !== mission.missionScore;
+    mission.score !== mission.missionScore;
+};
 
 const isLoading = ref(false);
 

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -226,8 +226,10 @@ console.log(choogoomiStore.choogoomiType);
 // 클릭(인증) 가능한 미션인지 확인
 //  -> 미션 타입 & 이미 수행했는지 확인
 const isClickableMission = mission => {
-  ['TEXT_INPUT', 'QUIZ'].includes(mission.missionType) &&
-    mission.score !== mission.missionScore;
+  return (
+    ['TEXT_INPUT', 'QUIZ'].includes(mission.missionType) &&
+    mission.score !== mission.missionScore
+  );
 };
 
 const isLoading = ref(false);

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -220,6 +220,7 @@ const isClickableMission = mission =>
 
 const showModal = ref(false); // 퀴즈 안내 모달
 const showResultModal = ref(false); // 매칭 결과 모달
+const selectedMission = ref(null); // 선택된 미션 (인증하려는 미션)
 
 // 사용자 프로필 정보
 const myUserData = ref({});
@@ -353,21 +354,22 @@ const MISSION_INFORMATION = [
 
 // 미션 클릭 -> 미션별로 미션페이지 매핑
 const goToMission = (missionType, missionId) => {
-  const selectedMission = myMissionList.value[missionId];
-  if (!selectedMission) return;
+  const mission = myMissionList.value[missionId];
+  if (!mission) return;
 
   // 글쓰기 미션 -> 미션 정보와 함께 페이지 이동
   if (missionType === 'TEXT_INPUT') {
     router.push({
       name: 'missionWrite',
       query: {
-        id: selectedMission.missionId,
-        title: selectedMission.missionTitle,
-        content: selectedMission.missionContent,
-        score: selectedMission.missionScore,
+        id: mission.missionId,
+        title: mission.missionTitle,
+        content: mission.missionContent,
+        score: mission.missionScore,
       },
     });
   } else if (missionType === 'QUIZ') {
+    selectedMission.value = mission;
     showModal.value = true;
   }
 };
@@ -377,13 +379,21 @@ const closeResultModal = () => {
   showResultModal.value = false;
 };
 
-// 글쓰기 미션 페이지로 이동
-const goToWrite = () => {
-  router.push({ name: 'missionWrite' });
-};
-
 // 퀴즈 미션 페이지로 이동
 const goToQuiz = () => {
-  router.push({ name: 'missionQuiz' });
+  if (!selectedMission.value) return;
+  router.push({
+    name: 'missionQuiz',
+    query: {
+      id: selectedMission.value.missionId,
+      missionScore: selectedMission.value.missionScore,
+      score: selectedMission.value.score,
+    },
+  });
+};
+
+// 퀴즈 모달 닫기
+const modalClose = () => {
+  showModal.value = false;
 };
 </script>

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -115,19 +115,12 @@
               <div
                 class="flex justify-between items-center bg-limegreen-100 w-full rounded-lg text-[13px] pl-2 py-2 text-limegreen-900"
                 :class="{
-                  'cursor-pointer hover:bg-limegreen-500 ':
-                    missionId === Object.keys(myMissionList)[0] ||
-                    missionId === Object.keys(myMissionList)[1],
+                  'cursor-pointer hover:bg-limegreen-500':
+                    isClickableMission(mission),
                 }"
                 @click="
-                  () => {
-                    const keys = Object.keys(myMissionList);
-                    return missionId === keys[0]
-                      ? goToWrite()
-                      : missionId === keys[1]
-                        ? confirmQuiz()
-                        : null;
-                  }
+                  isClickableMission(mission) &&
+                  goToMission(mission.missionType, missionId)
                 "
               >
                 <div>
@@ -219,6 +212,12 @@ import QuizAlertModal from './components/QuizAlertModal.vue';
 
 const router = useRouter();
 
+// 클릭(인증) 가능한 미션인지 확인
+//  -> 미션 타입 & 이미 수행했는지 확인
+const isClickableMission = mission =>
+  ['TEXT_INPUT', 'QUIZ'].includes(mission.missionType) &&
+  mission.score !== mission.missionScore;
+
 const showModal = ref(false); // 퀴즈 안내 모달
 const showResultModal = ref(false); // 매칭 결과 모달
 
@@ -294,10 +293,12 @@ onMounted(async () => {
       myMission.map(mission => [
         mission.missionId,
         {
+          missionId: mission.missionId,
           missionTitle: mission.missionTitle,
           missionContent: mission.missionContent,
           missionScore: mission.missionScore,
           score: mission.score,
+          missionType: mission.missionType,
         },
       ])
     );
@@ -313,6 +314,7 @@ onMounted(async () => {
           missionContent: mission.missionContent,
           missionScore: mission.missionScore,
           score: mission.score,
+          missionType: mission.missionType,
         },
       ])
     );
@@ -349,6 +351,27 @@ const MISSION_INFORMATION = [
   },
 ];
 
+// 미션 클릭 -> 미션별로 미션페이지 매핑
+const goToMission = (missionType, missionId) => {
+  const selectedMission = myMissionList.value[missionId];
+  if (!selectedMission) return;
+
+  // 글쓰기 미션 -> 미션 정보와 함께 페이지 이동
+  if (missionType === 'TEXT_INPUT') {
+    router.push({
+      name: 'missionWrite',
+      query: {
+        id: selectedMission.missionId,
+        title: selectedMission.missionTitle,
+        content: selectedMission.missionContent,
+        score: selectedMission.missionScore,
+      },
+    });
+  } else if (missionType === 'QUIZ') {
+    showModal.value = true;
+  }
+};
+
 // 매칭 결과 모달 닫기
 const closeResultModal = () => {
   showResultModal.value = false;
@@ -357,16 +380,6 @@ const closeResultModal = () => {
 // 글쓰기 미션 페이지로 이동
 const goToWrite = () => {
   router.push({ name: 'missionWrite' });
-};
-
-// 퀴즈 모달 열기
-const confirmQuiz = () => {
-  showModal.value = true;
-};
-
-// 퀴즈 모달 닫기
-const modalClose = () => {
-  showModal.value = false;
 };
 
 // 퀴즈 미션 페이지로 이동

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -13,7 +13,12 @@
           </div>
           <img :src="myUserData.profileImageUrl" class="w-[50px]" />
         </div>
-        <span class="text-limegreen-900 text-medium font-bold mt-3">VS</span>
+        <div class="flex flex-col item-center justify-center text-center">
+          <span class="bg-green text-white text-xs px-3 py-0.5 rounded-full">{{
+            choogoomiStore.choogoomiType
+          }}</span>
+          <span class="text-limegreen-900 text-medium font-bold mt-3">VS</span>
+        </div>
         <!-- 상대 -->
         <div class="flex flex-col flex-1 items-center justify-center">
           <div class="text-limegreen-900 text-xs mb-2">
@@ -216,6 +221,7 @@ import QuizAlertModal from './components/QuizAlertModal.vue';
 
 const router = useRouter();
 const choogoomiStore = useChoogoomiStore();
+console.log(choogoomiStore.choogoomiType);
 
 // 클릭(인증) 가능한 미션인지 확인
 //  -> 미션 타입 & 이미 수행했는지 확인

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -131,7 +131,8 @@
                     {{
                       (Object.keys(myMissionList)[0] === missionId
                         ? '공통 미션: '
-                        : '지출제로형 미션: ') + mission.missionTitle
+                        : choogoomiStore.choogoomiType + ' 미션: ') +
+                      mission.missionTitle
                     }}
                   </span>
                 </div>
@@ -205,12 +206,14 @@ import icon_info from '@/assets/img/icons/feature/icon_info.png';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
+import { useChoogoomiStore } from '@/stores/choogoomiStore';
 import { getLevel } from '@/utils/levelUtils';
 
 import MatchingResultModal from './components/MatchingResultModal.vue';
 import QuizAlertModal from './components/QuizAlertModal.vue';
 
 const router = useRouter();
+const choogoomiStore = useChoogoomiStore();
 
 // 클릭(인증) 가능한 미션인지 확인
 //  -> 미션 타입 & 이미 수행했는지 확인

--- a/src/views/matching/MissionQuizView.vue
+++ b/src/views/matching/MissionQuizView.vue
@@ -73,8 +73,9 @@
 
 <script setup>
 import { computed, ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
+import { validateQuizMission } from '@/api/matchingApi';
 import AlertModal from '@/components/AlertModal.vue';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
@@ -84,6 +85,15 @@ import ResultModal from './components/ResultModal.vue';
 import { QUIZ_LIST } from './quizData';
 
 const router = useRouter();
+
+const route = useRoute();
+
+// 전달받은 미션 정보
+const MISSION_INFO = {
+  missionId: route.query.id,
+  missionScore: route.query.missionScore,
+  score: route.query.score,
+};
 
 const currentIndex = ref(0);
 const selectedOption = ref(null);
@@ -155,9 +165,19 @@ const handleNext = () => {
   }
 };
 
-const handleQuizComplete = () => {
+const handleQuizComplete = async () => {
   showResultModal.value = false;
-  // 퀴즈 완료 후 이전 페이지로 이동하거나 다른 액션 수행
+
+  if (correctCount.value >= 3) {
+    MISSION_INFO.score = MISSION_INFO.missionScore;
+  }
+
+  try {
+    await validateQuizMission(MISSION_INFO.missionId, MISSION_INFO.score);
+  } catch (error) {
+    console.error('퀴즈 인증 요청 실패:', error);
+  }
+
   router.go(-1);
 };
 

--- a/src/views/matching/MissionWriteView.vue
+++ b/src/views/matching/MissionWriteView.vue
@@ -10,9 +10,7 @@
         <div class="text-limegreen-700 text-sm mt-2 whitespace-pre-line">
           {{ MISSION_LIST.missionContent }}
         </div>
-        <div class="text-red text-sm">
-          {{ '(' + MISSION_LIST.missionRestrict + '자 이상)' }}
-        </div>
+        <div class="text-red text-sm">(100자 이상)</div>
       </div>
       <div
         class="flex flex-col gap-5 bg-limegreen-100 px-4 rounded-lg text-center h-100"
@@ -28,8 +26,7 @@
           <div class="absolute bottom-0 right-3 text-sm">
             <p
               :class="
-                inputText.length < MISSION_LIST.missionRestrict ||
-                inputText.length == 500
+                inputText.length < 100 || inputText.length == 500
                   ? 'text-red'
                   : 'text-green'
               "
@@ -43,10 +40,10 @@
       <!-- 제출 버튼 -->
       <button
         @click="handleNext"
-        :disabled="inputText.length < MISSION_LIST.missionRestrict"
+        :disabled="inputText.length < 100"
         :class="[
           'w-full text-lg py-4 rounded-lg',
-          inputText.length < MISSION_LIST.missionRestrict
+          inputText.length < 100
             ? 'bg-ivory text-limegreen-500 border border-limegreen-500 cursor-not-allowed'
             : 'bg-limegreen-500 text-white',
         ]"
@@ -67,30 +64,30 @@
 
 <script setup>
 import { computed, ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
+import { validateWriteMission } from '@/api/matchingApi';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 
 import SuccessModal from './components/SuccessModal.vue';
+
+const route = useRoute();
+
+const MISSION_LIST = {
+  missionId: route.query.id,
+  missionTitle: route.query.title,
+  missionContent: route.query.content,
+  missionScore: route.query.score,
+};
 
 const inputText = ref('');
 const showSuccessModal = ref(false);
 
 const router = useRouter();
 
-const MISSION_LIST = {
-  missionId: 1,
-  missionTitle: '지출 반성문 쓰기',
-  missionContent:
-    '돌아보니... 이건 굳이 안 썼어도 됐다 🙈 \n오늘 안 써도 됐던 소비가 있다면, 여기 적으며 반성해봐요!',
-  missionCount: 1,
-  missionRestrict: 100,
-  missionScore: 10,
-};
-
 const isMissionCompleted = computed(() => {
-  return inputText.value.length >= MISSION_LIST.missionRestrict;
+  return inputText.value.length >= 100;
 });
 
 function handleNext() {
@@ -99,8 +96,14 @@ function handleNext() {
   }
 }
 
-function handleSuccessClose() {
-  showSuccessModal.value = false;
-  router.push('/matching');
+async function handleSuccessClose() {
+  try {
+    await validateWriteMission(MISSION_LIST.missionId);
+    showSuccessModal.value = false;
+    router.push('/matching');
+  } catch (error) {
+    alert('미션 인증에 실패했습니다.');
+    console.error(error);
+  }
 }
 </script>

--- a/src/views/matching/MissionWriteView.vue
+++ b/src/views/matching/MissionWriteView.vue
@@ -5,10 +5,10 @@
       <!-- 타이틀 -->
       <div class="flex flex-col text-center gap-2">
         <div class="tfont-bold text-2xl justify-center">
-          {{ MISSION_LIST.missionTitle }}
+          {{ MISSION_INFO.missionTitle }}
         </div>
         <div class="text-limegreen-700 text-sm mt-2 whitespace-pre-line">
-          {{ MISSION_LIST.missionContent }}
+          {{ MISSION_INFO.missionContent }}
         </div>
         <div class="text-red text-sm">(100자 이상)</div>
       </div>
@@ -56,7 +56,7 @@
     <SuccessModal
       v-if="showSuccessModal"
       title="미션 성공"
-      :message="MISSION_LIST.missionTitle"
+      :message="MISSION_INFO.missionTitle"
       @close="handleSuccessClose"
     />
   </div>
@@ -74,7 +74,8 @@ import SuccessModal from './components/SuccessModal.vue';
 
 const route = useRoute();
 
-const MISSION_LIST = {
+// 전달받은 미션 정보
+const MISSION_INFO = {
   missionId: route.query.id,
   missionTitle: route.query.title,
   missionContent: route.query.content,
@@ -82,10 +83,11 @@ const MISSION_LIST = {
 };
 
 const inputText = ref('');
-const showSuccessModal = ref(false);
+const showSuccessModal = ref(false); // 미션 성공 모달
 
 const router = useRouter();
 
+// 미션 완료 여부 조건: 100자 이상 작성
 const isMissionCompleted = computed(() => {
   return inputText.value.length >= 100;
 });
@@ -98,7 +100,7 @@ function handleNext() {
 
 async function handleSuccessClose() {
   try {
-    await validateWriteMission(MISSION_LIST.missionId);
+    await validateWriteMission(MISSION_INFO.missionId);
     showSuccessModal.value = false;
     router.push('/matching');
   } catch (error) {


### PR DESCRIPTION
## 📝 변경 내용

- 매칭페이지 미션타입별로 이동할 미션페이지 (글쓰기, 퀴즈) 연결 
- 추구미 유형명 homeview에서 pinia에 저장한 후 불러오기 구현
- 미션 성공 후 점수 반영 구현

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 미션타입별로 알맞은 미션페이지에 연결됨을 확인했습니다.
- [x] 페이지를 이동할 때 미션정보가 잘 전달됨을 확인했습니다.
- [x] 점수가 성공적으로 반영되는지 확인했습니다.
- [x] 추구미 유형이 pinia에 저장되어 매칭페이지에서 불러올 수 있음을 확인했습니다.  

---

## 📷 스크린샷(선택)

<img width="923" height="912" alt="image" src="https://github.com/user-attachments/assets/5e331291-6379-48ab-a3ff-8144947d5b70" />

---

## 💬 기타 참고 사항

choogoomiType을 pinia에 저장하는 방식으로 코드를 작성했는데요.
제 생각에는 `stores/authStore.js`의 내용과는 맞지 않는 것 같아서 새로 `stores/choogoomiStore.js`를 생성해서 저장했습니다!
그런데 내용이 하나 뿐이라 그냥 합치는게 나을지, 아니면 새로 store를 생성해서 저장한 방식 그대로 둘지 고민입니다.
다들 어떤게 나을 것 같나요?