### PR TITLE
feat: 추구 유형 LocalStorage에 저장 로직 추가

### DIFF
--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -60,6 +60,7 @@ export const useAuthStore = defineStore('auth', {
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
       localStorage.removeItem('userEmail');
+      localStorage.removeItem('choogoomiType');
 
       console.log('✅ 인증 정보 초기화 완료');
     },

--- a/src/stores/choogoomiStore.js
+++ b/src/stores/choogoomiStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 
+import { userInfo } from '@/api/authApi';
 import { updateChoogooMi } from '@/api/userApi';
 
 const CHOOGOOMI_TYPE = {
@@ -12,9 +13,23 @@ const CHOOGOOMI_TYPE = {
 
 export const useChoogoomiStore = defineStore('choogoomi', {
   state: () => ({
-    choogoomiType: '',
+    choogoomiType: localStorage.getItem('choogoomiType') || '',
   }),
   actions: {
+    async initializeChoogoomiType(userData = null) {
+      if (!localStorage.getItem('choogoomiType')) {
+        try {
+          // userData가 전달되면 그것을 사용, 없으면 API 호출
+          const data = userData || (await userInfo());
+          if (data.choogooMi) {
+            this.choogoomiType = CHOOGOOMI_TYPE[data.choogooMi];
+            localStorage.setItem('choogoomiType', this.choogoomiType);
+          }
+        } catch (error) {
+          console.error('사용자 정보 불러오기 실패:', error);
+        }
+      }
+    },
     async setChoogoomiType(type) {
       try {
         await updateChoogooMi(type);

--- a/src/stores/choogoomiStore.js
+++ b/src/stores/choogoomiStore.js
@@ -1,12 +1,28 @@
 import { defineStore } from 'pinia';
 
+import { updateChoogooMi } from '@/api/userApi';
+
+const CHOOGOOMI_TYPE = {
+  A: '지출제로형',
+  B: '합리소비형',
+  C: '저축실천형',
+  D: '투자도전형',
+  E: '금융탐구형',
+};
+
 export const useChoogoomiStore = defineStore('choogoomi', {
   state: () => ({
     choogoomiType: '',
   }),
   actions: {
-    setChoogoomiType(type) {
-      this.choogoomiType = type;
+    async setChoogoomiType(type) {
+      try {
+        await updateChoogooMi(type);
+        this.choogoomiType = CHOOGOOMI_TYPE[type];
+        localStorage.setItem('choogoomiType', this.choogoomiType);
+      } catch (error) {
+        console.error('추구미 선택 실패:', error);
+      }
     },
   },
 });

--- a/src/views/choogoomi/ChoogooMiSelectView.vue
+++ b/src/views/choogoomi/ChoogooMiSelectView.vue
@@ -65,14 +65,15 @@
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { updateChoogooMi } from '@/api/userApi';
 import AlertModal from '@/components/AlertModal.vue';
 import { CHOOGOOMI_CHARACTERS } from '@/constants/ChoogoomiList';
+import { useChoogoomiStore } from '@/stores/choogoomiStore';
 
 import ChoogooMiCard from './ChoogooMiCard.vue';
 import ChoogooMiDetailModal from './ChoogooMiDetailModal.vue';
 
 const router = useRouter();
+const choogoomiStore = useChoogoomiStore();
 
 const selected = ref(null);
 const isModalOpen = ref(false);
@@ -89,7 +90,8 @@ const select = idx => {
 const confirmSelection = async () => {
   try {
     // API 호출: 선택한 추구미로 업데이트
-    await updateChoogooMi(selected.value);
+    // 선택한 추구미 LocalStorage에 저장
+    await choogoomiStore.setChoogoomiType(selected.value);
     isSuccessModalOpen.value = true;
   } catch (error) {
     console.error('추구미 선택 실패:', error);

--- a/src/views/home/HomeView.vue
+++ b/src/views/home/HomeView.vue
@@ -228,6 +228,7 @@ onMounted(async () => {
   try {
     // 사용자 프로필 정보를 API로부터 받아옴
     const profileData = await userInfo();
+    choogoomiStore.initializeChoogoomiType(profileData);
 
     // 받아온 프로필 정보에 레벨 추가하여 저장
     USER_PROFILE.value = {
@@ -242,8 +243,6 @@ onMounted(async () => {
     choogoomi.value = CHOOGOOMI_MAP.find(
       item => item.choogoomiName === USER_PROFILE.value.choogooMi
     ).userLevel[userLevel.value];
-
-    choogoomiStore.setChoogoomiType(choogoomi.value.choogoomiType);
 
     // 추구미 캐릭터 이미지 URL
     choogoomiImage.value = new URL(

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -254,6 +254,7 @@ onMounted(async () => {
   try {
     isLoading.value = true;
     const matchingData = await fetchMatchingData();
+    choogoomiStore.initializeChoogoomiType();
 
     // 나의 프로필 정보
     const myData = matchingData.myMissionProgressList[0];


### PR DESCRIPTION
# 📌 추구 유형 LocalStorage에 저장
<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 홈, 매칭에서 추구 유형(한글이름)이 필요해서 localStorage에 저장 후 pinia에 저장되도록 하였습니다.
- 각 화면에서 처음에 LocalStorage에 저장하거나 value를 불러오도록 하였습니다.
---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 각 페이지에서 새로고침을 해도 데이터가 유지되는지 확인했습니다. 
- [x] 로그아웃 시에도 해당 값도 제거되도록 수정했습니다. 

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
localStorage에 저장되어 있지 않을 경우에 무조건 API 요청을 보내게 되면 home에서는 같은 요청을 두번 보내게 되어서 **인자를 받거나 인자가 없을 경우에 요청을 보내도록** 하였습니다! 
더 좋은 방법이 생각나시면 말씀해주세여~