### PR TITLE
feat : 지난주 매칭 결과 모달창

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -20,3 +20,8 @@ export function isEditableDay() {
   }
   return false;
 }
+
+//월요일 찾는 함수 (지난주 매칭 결과 확인용)
+export function isMonday() {
+  return new Date().getDay() === 1;
+}

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -199,8 +199,8 @@
 
     <!-- 매칭 결과 모달 -->
     <MatchingResultModal
-      v-if="showResultModal"
-      :round-number="2"
+      v-if="showResultModal && isMonday()"
+      :round-number="lastweekResult.roundNumber"
       title="지난주 매칭 결과"
       @close="closeResultModal"
     />
@@ -210,10 +210,11 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { fetchMatchingData } from '@/api/matchingApi';
+import { getRankingHistory } from '@/api/ranking';
 import icon_info from '@/assets/img/icons/feature/icon_info.png';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import LoadingScreen from '@/components/LoadingScreen.vue';
@@ -230,7 +231,10 @@ const router = useRouter();
 const isLoading = ref(false);
 
 const showModal = ref(false); // 퀴즈 안내 모달
-const showResultModal = ref(true); // 매칭 결과 모달
+const showResultModal = ref(false); // 매칭 결과 모달
+
+//지난주 매칭 결과 모달
+const lastweekResult = reactive({});
 
 // 사용자 프로필 정보
 const myUserData = ref({});
@@ -251,6 +255,14 @@ onMounted(async () => {
   try {
     isLoading.value = true;
     const matchingData = await fetchMatchingData();
+
+    //매칭 결과 모달에 띄울 데이터 가져오기
+    const result = await getRankingHistory();
+    //매칭 결과 중 가장 최근인 지난주 데이터(인덱스 0) 할당
+    Object.assign(lastweekResult, result[0]);
+
+    //지난주 매칭 결과를 가져온 뒤 모달 표시
+    showResultModal.value = true;
 
     // 나의 프로필 정보
     const myData = matchingData.myMissionProgressList[0];

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -198,7 +198,12 @@
     />
 
     <!-- 매칭 결과 모달 -->
-    <MatchingResultModal v-if="showResultModal" @close="closeResultModal" />
+    <MatchingResultModal
+      v-if="showResultModal"
+      :round-number="2"
+      title="지난주 매칭 결과"
+      @close="closeResultModal"
+    />
 
     <BottomNavigation />
   </div>
@@ -214,6 +219,7 @@ import BottomNavigation from '@/components/BottomNavigation.vue';
 import LoadingScreen from '@/components/LoadingScreen.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 import { CHOOGOOMI_MAP } from '@/constants/choogoomiMap';
+import { isMonday } from '@/utils/dateUtils';
 import { getLevel } from '@/utils/levelUtils';
 
 import MatchingResultModal from './components/MatchingResultModal.vue';
@@ -224,7 +230,7 @@ const router = useRouter();
 const isLoading = ref(false);
 
 const showModal = ref(false); // 퀴즈 안내 모달
-const showResultModal = ref(false); // 매칭 결과 모달
+const showResultModal = ref(true); // 매칭 결과 모달
 
 // 사용자 프로필 정보
 const myUserData = ref({});


### PR DESCRIPTION
# 📌 지난주 매칭 결과 모달창

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 월요일에 매칭 화면에 접속하면 지난주 매칭 결과 모달창이 뜨도록 했습니다.
- 가장 최근의 매칭 기록을 가져와 모달창과 연결했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 설정한 요일에 따라 모달창이 뜨는지 확인했습니다.
- [x] 가장 최근의 매칭 기록을 가져오는지 확인했습니다.
---

## 📷 스크린샷(선택)
<img width="243" height="436" alt="localhost_5173_matching(노트북)" src="https://github.com/user-attachments/assets/34e7b00d-7588-4502-b2fa-45ae16ec03c6" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항
지금은 월요일에 매칭 페이지를 들어갈 때마다 모달창이 뜨게 되어있는데 사용자 입장에서는 번거롭지 않을까 라는 생각이 들기도 합니다..
만약 모달창이 최초로 한 번만 뜨도록 하려면 로컬이나 어딘가에 모달 표시 여부를 저장해야할 것 같은데 어떻게 하는게 좋을까요!
<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
