### PR TITLE
fix: 랭킹페이지 top3 모달 조건 수정

### DIFF
--- a/src/views/ranking/RankingView.vue
+++ b/src/views/ranking/RankingView.vue
@@ -280,6 +280,16 @@ const loadRankingData = async () => {
       secondRankUser.value = lastRankingList.value[1] || {};
       thirdRankUser.value = lastRankingList.value[2] || {};
 
+      // 유저 닉네임이 지난주 랭킹 top3에 포함되면 모달 표시
+      // 데이터 세팅 후 실행
+      if (
+        [firstRankUser, secondRankUser, thirdRankUser].some(
+          user => user && user.value.userNickname === userProfile.value.nickname
+        )
+      ) {
+        showModal.value = true;
+      }
+
       //  모든 요청이 성공하면 로딩 완료
       isLoading.value = false;
     } else {
@@ -293,14 +303,6 @@ const loadRankingData = async () => {
 onMounted(() => {
   loadRankingData();
 });
-// 유저 닉네임이 지난주 랭킹 top3에 포함되면 모달 표시
-if (
-  [firstRankUser, secondRankUser, thirdRankUser].some(
-    user => user && user.userNickname === userProfile.value.nickname
-  )
-) {
-  showModal.value = true;
-}
 
 // 쭈꾸미 유형 가져오기
 const getChoogoomiType = userData => {


### PR DESCRIPTION
## 📝 변경 내용

### 랭킹페이지 top3 선정 시 모달 창 뜨는 조건 수정
- '.value' 추가
- 모달창 표시 여부: 페이지가 mount 되자마자 -> 데이터가 세팅된 후

---

## ✅ 체크리스트

- [x] top3가 아닐 경우 모달이 뜨지 않는 것을 확인했습니다.
- [x] top3가 맞을 경우 모달이 뜨는 것을 확인했습니다. 

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

