### PR TITLE
fix: 사전조사 다시하기 완료 시 마이페이지로 이동하도록 수정 & 설문조사 hover스타일 수정

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -17,6 +17,7 @@ import MyPageAssetReportView from '@/views/mypage/components/report/AssetReportV
 import MyPageEditInfoView from '@/views/mypage/MyPageEditInfoView.vue';
 import MyPageRecordView from '@/views/mypage/MyPageRecordView.vue';
 import MyPageView from '@/views/mypage/MyPageView.vue';
+import MyPageSurveyView from '@/views/mypage/survey/MyPageSurveyView.vue';
 import RankingView from '@/views/ranking/RankingView.vue';
 import SurveyView from '@/views/signup/components/survey/SurveyView.vue';
 import SignupView from '@/views/signup/SignupView.vue';
@@ -127,6 +128,11 @@ const router = createRouter({
       path: '/mypage/asset-report',
       name: 'mypageAssetReport',
       component: MyPageAssetReportView,
+    },
+    {
+      path: '/mypage/survey',
+      name: 'mypageSurvey',
+      component: MyPageSurveyView,
     },
   ],
 });

--- a/src/views/mypage/MyPageView.vue
+++ b/src/views/mypage/MyPageView.vue
@@ -86,7 +86,7 @@
           <div class="flex flex-col gap-2.5">
             <MyPageBtn text="나의 자산 분석 리포트" to="mypageAssetReport" />
             <MyPageBtn text="나의 매칭 기록" to="mypageRecord" />
-            <MyPageBtn text="사전 조사 다시하기" to="survey" />
+            <MyPageBtn text="사전 조사 다시하기" to="mypageSurvey" />
             <MyPageBtn text="회원 정보 수정" to="mypageEditInfo" />
             <button
               class="w-full bg-ivory border-2 border-limegreen-500 text-limegreen-500 h-12 rounded-[10px]"

--- a/src/views/mypage/survey/MyPageSurveyOneComponent.vue
+++ b/src/views/mypage/survey/MyPageSurveyOneComponent.vue
@@ -3,7 +3,9 @@
     <div class="bg-ivory flex flex-col gap-6 w-full px-6">
       <!-- 타이틀 -->
       <div class="flex flex-col text-center gap-2">
-        <div class="font-bold text-2xl justify-center">사전 조사</div>
+        <div class="font-bold flex h-14 text-2xl justify-center items-center">
+          사전 조사
+        </div>
         <div class="text-limegreen-700 text-sm">
           현재 자산 유형 분석을 위한 질문입니다.
         </div>

--- a/src/views/mypage/survey/MyPageSurveyOneComponent.vue
+++ b/src/views/mypage/survey/MyPageSurveyOneComponent.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="flex justify-center w-full">
+    <div class="bg-ivory flex flex-col gap-6 w-full px-6">
+      <!-- 타이틀 -->
+      <div class="flex flex-col text-center gap-2">
+        <div class="font-bold text-2xl justify-center">사전 조사</div>
+        <div class="text-limegreen-700 text-sm">
+          현재 자산 유형 분석을 위한 질문입니다.
+        </div>
+      </div>
+
+      <!-- 설문조사 문항 -->
+      <div class="flex flex-col gap-5">
+        <div
+          v-for="question in surveyList"
+          :key="question.id"
+          class="flex flex-col gap-3 bg-ivory rounded-lg"
+        >
+          <!-- 질문 제목 -->
+          <div
+            class="px-3 py-1 rounded-lg flex bg-limegreen-100 justify-between items-center"
+          >
+            <div class="flex items-center">
+              <div class="font-thin text-sm text-limegreen-800">
+                {{ question.title }}
+              </div>
+              <div
+                v-if="question.subtitle"
+                class="text-xs text-gray-300 font-thin px-1"
+              >
+                {{ question.subtitle }}
+              </div>
+            </div>
+            <div v-if="question.priceUnit" class="text-xs text-gray-300">
+              {{ question.priceUnit }}
+            </div>
+          </div>
+
+          <div class="relative">
+            <div
+              class="absolute top-3 left-6 right-6 h-0.5 bg-limegreen-500 z-0"
+            ></div>
+
+            <!-- 설문조사 응답 버튼과 라벨 -->
+            <div class="grid grid-cols-5 gap-0 relative z-10">
+              <div v-for="option in question.options" :key="option.value">
+                <!-- 각 옵션을 컨테이너로 묶기 -->
+                <div class="flex flex-col items-center">
+                  <div
+                    @click="selectOption(question.id, option.value)"
+                    :class="[
+                      'w-6 h-6 rounded-full border-2 text-gray-300 border-limegreen-500 flex items-center justify-center text-xs cursor-pointer ',
+                      answers[question.id] === option.value
+                        ? 'bg-limegreen-100'
+                        : 'bg-white hover:bg-limegreen-100',
+                    ]"
+                  >
+                    {{ option.value }}
+                  </div>
+                  <!-- 라벨 -->
+                  <div
+                    class="text-xs text-center text-gray-300 mt-1 whitespace-pre-line"
+                  >
+                    {{ option.label }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 다음 버튼 -->
+      <button
+        @click="handleNext"
+        class="w-full bg-limegreen-500 text-white text-lg py-4 rounded-lg"
+      >
+        다음
+      </button>
+
+      <!--선택하지 않은 항목이 있을 때 모달 -->
+      <AlertModal
+        v-if="showModal"
+        title="알림"
+        message="모든 항목에 응답해주세요."
+        buttonText="확인"
+        @close="showModal = false"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue';
+
+import AlertModal from '@/components/AlertModal.vue';
+import { SURVEY_LIST } from '@/views/signup/constants/survey';
+
+const emit = defineEmits(['next']);
+
+const surveyList = SURVEY_LIST.filter(question => question.id <= 3);
+
+// 답변
+const answers = reactive(Array(surveyList.length).fill(null));
+
+// 모달 상태
+const showModal = ref(false);
+
+// 응답 선택
+const selectOption = (questionId, value) => {
+  answers[questionId] = value;
+};
+
+// 다음 버튼 클릭 시
+function handleNext() {
+  //answers의 value들을 배열에 담아 값이 null이 아닌지(모든 항목이 선택되었는지) 확인
+  if (answers.some(answer => answer === null)) {
+    showModal.value = true;
+    return;
+  }
+  emit('next', answers);
+}
+</script>

--- a/src/views/mypage/survey/MyPageSurveyOneComponent.vue
+++ b/src/views/mypage/survey/MyPageSurveyOneComponent.vue
@@ -51,9 +51,9 @@
                   <div
                     @click="selectOption(question.id, option.value)"
                     :class="[
-                      'w-6 h-6 rounded-full border-2 text-gray-300 border-limegreen-500 flex items-center justify-center text-xs cursor-pointer ',
+                      'w-6 h-6 rounded-full border-2 text-gray-300 border-limegreen-500 flex items-center justify-center text-xs cursor-pointer hover:-translate-y-0.3 hover:shadow-md',
                       answers[question.id] === option.value
-                        ? 'bg-limegreen-100'
+                        ? 'bg-limegreen-500'
                         : 'bg-white hover:bg-limegreen-100',
                     ]"
                   >

--- a/src/views/mypage/survey/MyPageSurveyTwoComponent.vue
+++ b/src/views/mypage/survey/MyPageSurveyTwoComponent.vue
@@ -3,7 +3,9 @@
     <div class="bg-ivory flex flex-col gap-6 w-full px-6 justify-between">
       <!-- 타이틀 -->
       <div class="flex flex-col text-center gap-2">
-        <div class="tfont-bold text-2xl justify-center">사전 조사</div>
+        <div class="font-bold flex h-14 text-2xl justify-center items-center">
+          사전 조사
+        </div>
         <div class="text-limegreen-700 text-sm">
           추구 유형 추천을 위한 질문입니다.
         </div>

--- a/src/views/mypage/survey/MyPageSurveyTwoComponent.vue
+++ b/src/views/mypage/survey/MyPageSurveyTwoComponent.vue
@@ -44,7 +44,7 @@
           isProcessing
             ? '처리 중...'
             : currentIndex === surveyList.length - 1
-              ? '자산 연동'
+              ? '제출하기'
               : '다음'
         }}
       </button>

--- a/src/views/mypage/survey/MyPageSurveyTwoComponent.vue
+++ b/src/views/mypage/survey/MyPageSurveyTwoComponent.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="flex justify-center w-full">
+    <div class="bg-ivory flex flex-col gap-6 w-full px-6 justify-between">
+      <!-- 타이틀 -->
+      <div class="flex flex-col text-center gap-2">
+        <div class="tfont-bold text-2xl justify-center">사전 조사</div>
+        <div class="text-limegreen-700 text-sm">
+          추구 유형 추천을 위한 질문입니다.
+        </div>
+      </div>
+
+      <!-- Progress Bar -->
+      <div>
+        <div class="w-full h-2 bg-limegreen-100 rounded-full">
+          <div
+            class="h-full bg-green rounded-full transition-all"
+            :style="{
+              width: `${((currentIndex + 1) / surveyList.length) * 100}%`,
+            }"
+          ></div>
+        </div>
+        <div class="flex items-center text-xs mt-1 text-limegreen-700">
+          <div class="text-sm text-green">
+            {{ currentIndex + 1 }}
+          </div>
+          <div class="px-1">/ {{ surveyList.length }}</div>
+        </div>
+      </div>
+
+      <!-- 질문 카드 컴포넌트 -->
+      <QuestionCard
+        :question="currentQuestion"
+        :selectedOption="selectedOption"
+        @select="val => (selectedOption = val)"
+      />
+
+      <!-- 다음 버튼 -->
+      <button
+        @click="handleNext"
+        class="w-full bg-limegreen-500 text-white text-lg py-4 rounded-lg disabled:opacity-50"
+        :disabled="isProcessing"
+      >
+        {{
+          isProcessing
+            ? '처리 중...'
+            : currentIndex === surveyList.length - 1
+              ? '자산 연동'
+              : '다음'
+        }}
+      </button>
+
+      <!--선택하지 않은 항목이 있을 때 모달 -->
+      <AlertModal
+        v-if="showModal"
+        title="알림"
+        message="질문에 응답해주세요."
+        buttonText="확인"
+        @close="showModal = false"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+
+import AlertModal from '@/components/AlertModal.vue';
+import QuestionCard from '@/views/signup/components/survey/QuestionCard.vue';
+import { SURVEY_LIST } from '@/views/signup/constants/survey';
+
+// Emit 정의
+const emit = defineEmits(['next']);
+
+// 설문 2 목록
+const surveyList = SURVEY_LIST.filter(question => question.id >= 4);
+
+// 현재 질문 인덱스
+const currentIndex = ref(0);
+
+// 선택된 옵션
+const selectedOption = ref(null);
+
+// 모달 상태
+const showModal = ref(false);
+
+// 로딩 상태 관리
+const isProcessing = ref(false);
+
+// survey2 답변들을 저장할 배열
+const survey2Answers = ref([selectedOption.value]);
+
+// 현재 질문
+const currentQuestion = computed(() => surveyList[currentIndex.value]);
+
+const isLastSurvey = computed(
+  () => currentIndex.value === surveyList.length - 1
+);
+
+const handleNext = () => {
+  // 선택된 옵션이 없을 때
+  if (!selectedOption.value) {
+    showModal.value = true;
+    return;
+  }
+  // 현재 질문의 답변을 저장
+  survey2Answers.value[currentIndex.value] = selectedOption.value;
+
+  // 마지막 질문일 때
+  if (isLastSurvey.value) {
+    emit('next', survey2Answers.value);
+    return;
+  }
+
+  // 다음 질문으로 이동
+  currentIndex.value++;
+  selectedOption.value = null;
+};
+</script>

--- a/src/views/mypage/survey/MyPageSurveyView.vue
+++ b/src/views/mypage/survey/MyPageSurveyView.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="min-h-screen bg-ivory">
+  <div class="relative min-h-screen bg-ivory">
+    <TopNavigation :show-back="true" :show-logo-text="false" />
     <!-- 설문 1 -->
     <SurveyOneComponent
       v-if="currentStep === 1"
@@ -26,6 +27,7 @@ import { useRouter } from 'vue-router';
 
 import { submitSurvey } from '@/api/userApi';
 import AlertModal from '@/components/AlertModal.vue';
+import TopNavigation from '@/components/TopNavigation.vue';
 
 import SurveyOneComponent from './MyPageSurveyOneComponent.vue';
 import SurveyTwoComponent from './MyPageSurveyTwoComponent.vue';

--- a/src/views/mypage/survey/MyPageSurveyView.vue
+++ b/src/views/mypage/survey/MyPageSurveyView.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="min-h-screen bg-ivory">
+    <!-- 설문 1 -->
+    <SurveyOneComponent
+      v-if="currentStep === 1"
+      @next="handleSurveyOneComplete"
+    />
+
+    <!-- 설문 2 -->
+    <SurveyTwoComponent
+      v-if="currentStep === 2"
+      @next="handleSurveyTwoComplete"
+    />
+    <AlertModal
+      v-if="isSuccessModalOpen"
+      title="설문 제출 완료"
+      message="설문 제출이 완료되었습니다."
+      @close="handleModalClose"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+import { submitSurvey } from '@/api/userApi';
+import AlertModal from '@/components/AlertModal.vue';
+
+import SurveyOneComponent from './MyPageSurveyOneComponent.vue';
+import SurveyTwoComponent from './MyPageSurveyTwoComponent.vue';
+
+const router = useRouter();
+// 현재 설문 단계 (1: 첫 번째 설문, 2: 두 번째 설문)
+const currentStep = ref(1);
+
+// 설문 데이터를 저장할 평면 배열 [설문1답변1, 설문1답변2, ..., 설문2답변1, 설문2답변2, ...] (총 14개)
+const surveyAnswers = ref([]);
+
+const isSuccessModalOpen = ref(false);
+
+// 설문 1 완료 처리
+const handleSurveyOneComplete = surveyOneAnswers => {
+  // 배열을 평면화하여 추가 (spread operator 사용)
+  surveyAnswers.value.push(...surveyOneAnswers);
+  // 다음 설문으로 이동
+  currentStep.value = 2;
+};
+
+// 설문 2 완료 처리
+const handleSurveyTwoComplete = surveyTwoAnswers => {
+  // 설문 2 답변들도 평면화하여 추가
+  surveyAnswers.value.push(...surveyTwoAnswers);
+  // 최종 설문 데이터 출력 (총 14개 값이 하나의 배열에)
+  sendSurveyData();
+};
+
+// API 요청 형식으로 변환하는 함수
+const convertToRequestData = () => {
+  // 문제의 id값은 1부터 14까지
+  return {
+    surveyAnswers: surveyAnswers.value.map((answer, index) => ({
+      surveyQuestionId: index + 1,
+      surveyAnswerId: answer,
+    })),
+  };
+};
+
+const sendSurveyData = async () => {
+  const requestData = convertToRequestData();
+
+  await submitSurvey(requestData);
+  isSuccessModalOpen.value = true;
+};
+
+const handleModalClose = () => {
+  isSuccessModalOpen.value = false;
+  router.push('/asset/select');
+};
+</script>

--- a/src/views/mypage/survey/MyPageSurveyView.vue
+++ b/src/views/mypage/survey/MyPageSurveyView.vue
@@ -75,6 +75,6 @@ const sendSurveyData = async () => {
 
 const handleModalClose = () => {
   isSuccessModalOpen.value = false;
-  router.push('/asset/select');
+  router.push('/mypage');
 };
 </script>

--- a/src/views/signup/components/survey/QuestionCard.vue
+++ b/src/views/signup/components/survey/QuestionCard.vue
@@ -19,11 +19,11 @@
         :key="index"
         @click="$emit('select', option.value)"
         :class="[
-          'flex justify-center items-center border-2 border-limegreen-500 rounded-lg p-3 text-sm! whitespace-pre-line',
+          'flex justify-center items-center border-2 border-limegreen-500 rounded-lg p-3 text-sm! whitespace-pre-line hover:-translate-y-0.3 hover:shadow-md',
           question.type === 2 ? 'h-35' : 'h-11',
           selectedOption === option.value
             ? 'bg-limegreen-500 text-ivory'
-            : 'bg-ivory text-limegreen-700 bg hover:bg-limegreen-500 hover:text-ivory',
+            : 'bg-ivory text-limegreen-700 hover:bg-white',
         ]"
       >
         {{ option.label }}

--- a/src/views/signup/components/survey/SurveyOneComponent.vue
+++ b/src/views/signup/components/survey/SurveyOneComponent.vue
@@ -49,9 +49,9 @@
                   <div
                     @click="selectOption(question.id, option.value)"
                     :class="[
-                      'w-6 h-6 rounded-full border-2 text-gray-300 border-limegreen-500 flex items-center justify-center text-xs cursor-pointer ',
+                      'w-6 h-6 rounded-full border-2 text-gray-300 border-limegreen-500 flex items-center justify-center text-xs cursor-pointer hover:-translate-y-0.3 hover:shadow-md',
                       answers[question.id] === option.value
-                        ? 'bg-limegreen-100'
+                        ? 'bg-limegreen-500'
                         : 'bg-white hover:bg-limegreen-100',
                     ]"
                   >


### PR DESCRIPTION
# 📌 사전조사 다시하기 완료 시 마이페이지로 이동하도록 수정 &  hover스타일 수정

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 마이페이지에서 사전조사 다시하기 완료 시 자산 연동이 아닌 마이페이지로 이동하도록 수정
- 사전조사 옵션 hover일때와 선택했을 때 스타일 다르도록 수정
- 사전조사 다시하기 페이지에 TopNavigation을 추가했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 사전조사 다시하기 완료시 마이페이지로 이동하는지 확인했습니다.
- [x] hover일때와 선택했을 때가 명확하게 구분되도록 스타일을 수정했습니다. 
- [x] 사전조사 다시하기 페이지의 TopNavigation이 잘 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)
<img width="243" height="436" alt="localhost_5173_survey(노트북)" src="https://github.com/user-attachments/assets/60f9244b-275d-4689-9cb3-62d857c3703b" />
<img width="243" height="436" alt="localhost_5173_survey(노트북) (1)" src="https://github.com/user-attachments/assets/fc9c063c-5deb-4faf-9159-e66cf89b27d5" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
