### PR TITLE
feat: 수정된 텍스트 미션 API 연결

### DIFF
--- a/src/api/matchingApi.js
+++ b/src/api/matchingApi.js
@@ -25,11 +25,11 @@ export const getResultByRound = async roundNumber => {
 };
 
 // 글쓰기 미션 인증 요청
-export const validateWriteMission = async missionId => {
+export const validateWriteMission = async (missionId, contents) => {
   try {
     const response = await axiosInstance.put(
       `/api/matching/missions/validate/3`,
-      { missionId }
+      { missionId, contents }
     );
     return response.data;
   } catch (error) {

--- a/src/views/matching/MissionWriteView.vue
+++ b/src/views/matching/MissionWriteView.vue
@@ -59,6 +59,13 @@
       :message="MISSION_INFO.missionTitle"
       @close="handleSuccessClose"
     />
+
+    <AlertModal
+      v-if="showFailModal"
+      title="미션 인증 실패"
+      :message="MISSION_INFO.missionTitle"
+      @close="handleRetry"
+    />
   </div>
 </template>
 
@@ -67,6 +74,7 @@ import { computed, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import { validateWriteMission } from '@/api/matchingApi';
+import AlertModal from '@/components/AlertModal.vue';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
 
@@ -76,7 +84,7 @@ const route = useRoute();
 
 // 전달받은 미션 정보
 const MISSION_INFO = {
-  missionId: route.query.id,
+  missionId: Number(route.query.id),
   missionTitle: route.query.title,
   missionContent: route.query.content,
   missionScore: route.query.score,
@@ -84,6 +92,7 @@ const MISSION_INFO = {
 
 const inputText = ref('');
 const showSuccessModal = ref(false); // 미션 성공 모달
+const showFailModal = ref(false); // 미션 인증 실패 모달
 
 const router = useRouter();
 
@@ -92,20 +101,46 @@ const isMissionCompleted = computed(() => {
   return inputText.value.length >= 100;
 });
 
-function handleNext() {
-  if (isMissionCompleted.value) {
-    showSuccessModal.value = true;
-  }
-}
-
-async function handleSuccessClose() {
+// 미션 제출 후 성공 여부 판단
+const submitMission = async missionId => {
   try {
-    await validateWriteMission(MISSION_INFO.missionId);
-    showSuccessModal.value = false;
-    router.push('/matching');
+    const data = await validateWriteMission(missionId, inputText.value);
+    // 미션 성공 여부 판단하기 위해 응답 데이터에 접근
+    const list = data.missionProgressDTOList;
+    const missionIdNumber = Number(missionId);
+    const missionData = list.find(
+      item => Number(item.missionId) === missionIdNumber
+    );
+    // 해당 미션 점수가 0이 아닌 경우 성공
+    const isSuccess = Number(missionData.score) !== 0;
+    return isSuccess;
   } catch (error) {
-    alert('미션 인증에 실패했습니다.');
-    console.error(error);
+    throw new Error(error);
   }
-}
+};
+// 미션 성공 여부 판단 후 모달 표시
+const handleNext = async () => {
+  if (!isMissionCompleted.value) {
+    return;
+  }
+  const isSuccess = await submitMission(MISSION_INFO.missionId);
+  if (isSuccess) {
+    showSuccessModal.value = true;
+    return;
+  }
+  showFailModal.value = true;
+  return;
+};
+
+// 미션 성공 모달 닫기
+const handleSuccessClose = () => {
+  showSuccessModal.value = false;
+  router.push('/matching');
+};
+
+// 미션 인증 실패 모달 닫기
+const handleRetry = () => {
+  showFailModal.value = false;
+  router.go(-1);
+};
 </script>


### PR DESCRIPTION
# 📌 수정된 텍스트 미션 API 연결

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 기존에는 `missionId`만 넘겨주던 API를 `missionId`, `contents`를 같이 넘기도록 수정했습니다.
- 요청을 보내고 반환된 응답 데이터에서 해당되는 미션의 score값이 0이 아닌 경우에 미션 성공으로 판단되도록 하였습니다.
- 미션 실패했을 경우에는 실패 모달을 띄우도록 하였습니다.(사진 첨부)

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->
<img width="337" height="683" alt="스크린샷 2025-08-12 오후 1 00 41" src="https://github.com/user-attachments/assets/79b309dd-3552-41cf-bf7e-0454a7d3a429" />

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
일관된 스타일로 통일하는 것이 좋다고 판단해서 화살표 함수로 수정하고 선언했습니다!
화살표 함수는 호이스팅이 되지 않아 순서에 민감하지만, 저희가 순서대로 선언이 지켜져서 괜찮은 것 같습니다.