### PR TITLE
fix: 매칭된 적 없는 유저 에러 처리

### DIFF
--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -1,5 +1,15 @@
 <template>
-  <LoadingScreen v-if="isLoading" class="h-screen" />
+  <div
+    v-if="isFailMatching"
+    class="h-screen flex items-center justify-center bg-ivory"
+  >
+    <AlertModal
+      title="매칭 시작 전입니다."
+      :message="MATCHING_ERROR_MESSAGE"
+      @close="handleRetry"
+    />
+  </div>
+  <LoadingScreen v-else-if="isLoading" class="h-screen" />
   <div v-else class="relative flex justify-center">
     <TopNavigation />
     <div class="flex flex-col w-full min-h-[calc(100vh-120px)] bg-ivory mt-18">
@@ -219,6 +229,7 @@ import { useRouter } from 'vue-router';
 import { fetchMatchingData } from '@/api/matchingApi';
 import { getRankingHistory } from '@/api/ranking';
 import icon_info from '@/assets/img/icons/feature/icon_info.png';
+import AlertModal from '@/components/AlertModal.vue';
 import BottomNavigation from '@/components/BottomNavigation.vue';
 import LoadingScreen from '@/components/LoadingScreen.vue';
 import TopNavigation from '@/components/TopNavigation.vue';
@@ -243,6 +254,8 @@ const isClickableMission = mission => {
 };
 
 const isLoading = ref(false);
+const isFailMatching = ref(false); // 매칭 데이터 불러오기 실패 모달
+const MATCHING_ERROR_MESSAGE = '다음 주 월요일 00:00에 매칭이 시작됩니다.';
 
 const showModal = ref(false); // 퀴즈 안내 모달
 const showResultModal = ref(false); // 매칭 결과 모달
@@ -388,7 +401,8 @@ onMounted(async () => {
 
     isLoading.value = false;
   } catch (err) {
-    console.error('매칭 데이터 불러오기 실패:', err);
+    isLoading.value = false;
+    isFailMatching.value = true;
   }
 });
 
@@ -454,5 +468,10 @@ const goToQuiz = () => {
 // 퀴즈 모달 닫기
 const modalClose = () => {
   showModal.value = false;
+};
+
+// 매칭 데이터 로딩 실패 모달 확인 → 홈으로 이동
+const handleRetry = () => {
+  router.replace({ name: 'home' });
 };
 </script>

--- a/src/views/matching/MatchingView.vue
+++ b/src/views/matching/MatchingView.vue
@@ -255,7 +255,7 @@ const isClickableMission = mission => {
 
 const isLoading = ref(false);
 const isFailMatching = ref(false); // 매칭 데이터 불러오기 실패 모달
-const MATCHING_ERROR_MESSAGE = '다음 주 월요일 00:00에 매칭이 시작됩니다.';
+const MATCHING_ERROR_MESSAGE = '다음 주 월요일 09:00에 매칭이 시작됩니다.';
 
 const showModal = ref(false); // 퀴즈 안내 모달
 const showResultModal = ref(false); // 매칭 결과 모달


### PR DESCRIPTION
# 📌 매칭 된 적 없는 유저가 매칭 페이지 접근 시 안내 창 추가

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 회원가입 후 매칭이 시작되지 않아 매칭이 잡히지 않은 유저가 매칭 페이지에 진입하면 무한로딩이 되었습니다. 매칭 시작 전 안내 모달을 띄워서 홈으로 리다이렉트되도록 작업했습니다.

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->
<img width="384" height="792" alt="스크린샷 2025-08-12 오후 1 45 57" src="https://github.com/user-attachments/assets/2df594b7-307c-4dae-91f6-9ca520d016c9" />

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
