### PR TITLE
feat: 카카오 로그인 기능 추가

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 import axiosInstance from './axios';
 
 export const checkName = async name => {
@@ -98,5 +100,22 @@ export const findPassword = async (email, verificationCode, newPassword) => {
     return true;
   } catch {
     return false;
+  }
+};
+
+export const kakaoLogin = async code => {
+  try {
+    const { data } = await axios.post(
+      'http://localhost:8080/api/v1/oauth2/kakao/login',
+      {
+        code,
+      }
+    );
+    const { accessToken, refreshToken } = data;
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
+    return true;
+  } catch {
+    throw new Error('카카오 로그인 실패');
   }
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,7 @@ import SurveyView from '@/views/signup/components/survey/SurveyView.vue';
 import SignupView from '@/views/signup/SignupView.vue';
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(import.meta.env.API_BASE_URL),
   routes: [
     {
       path: '/',
@@ -54,6 +54,13 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: LoginView,
+      beforeEnter: async (to, from, next) => {
+        const userData = await userInfo();
+        if (userData.choogooMi === 'O') {
+          return next('/survey');
+        }
+        next();
+      },
     },
     {
       path: '/kakao',
@@ -150,7 +157,7 @@ router.beforeEach(async (to, from, next) => {
   const isLoggedIn = authStore.isLoggedIn;
 
   // 공개 페이지 정의
-  const publicPages = ['/login', '/signup', '/find-password'];
+  const publicPages = ['/login', '/signup', '/find-password', '/kakao'];
 
   console.log('🚦 Router Guard:', {
     to: to.path,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -54,13 +54,6 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: LoginView,
-      beforeEnter: async (to, from, next) => {
-        const userData = await userInfo();
-        if (userData.choogooMi === 'O') {
-          return next('/survey');
-        }
-        next();
-      },
     },
     {
       path: '/kakao',

--- a/src/views/kakao/KakaoLoginView.vue
+++ b/src/views/kakao/KakaoLoginView.vue
@@ -4,5 +4,28 @@
   </div>
 </template>
 <script setup>
+import { onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { useRouter } from 'vue-router';
+
+import { kakaoLogin, userInfo } from '@/api/authApi';
 import LoadingScreen from '@/components/LoadingScreen.vue';
+
+const route = useRoute();
+const code = route.query.code;
+const router = useRouter();
+
+const handleKakaoLogin = async () => {
+  try {
+    await kakaoLogin(code);
+    await userInfo();
+    router.push('/');
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+onMounted(() => {
+  handleKakaoLogin();
+});
 </script>

--- a/src/views/kakao/KakaoLoginView.vue
+++ b/src/views/kakao/KakaoLoginView.vue
@@ -10,15 +10,18 @@ import { useRouter } from 'vue-router';
 
 import { kakaoLogin, userInfo } from '@/api/authApi';
 import LoadingScreen from '@/components/LoadingScreen.vue';
+import { useAuthStore } from '@/stores/authStore';
 
 const route = useRoute();
 const code = route.query.code;
 const router = useRouter();
+const authStore = useAuthStore();
 
 const handleKakaoLogin = async () => {
   try {
-    await kakaoLogin(code);
-    await userInfo();
+    await kakaoLogin(code); // localStorage에 토큰 저장됨
+    authStore.initializeAuth(); // Pinia로 즉시 반영
+    // await userInfo(); // 선택: 프로필 선조회
     router.push('/');
   } catch (error) {
     console.error(error);

--- a/src/views/login/LoginView.vue
+++ b/src/views/login/LoginView.vue
@@ -90,6 +90,7 @@
           <div class="flex gap-2">
             <button
               class="flex flex-1 items-center justify-center gap-2 rounded-[10px] bg-[#ffe812] h-12 text-black shadow-sm"
+              @click="handleKakaoLogin"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -199,5 +200,9 @@ const navigateToFindPassword = () => {
 
 const goToSignup = () => {
   router.push('/signup');
+};
+
+const handleKakaoLogin = () => {
+  window.location.href = import.meta.env.VITE_KAKAO_API_URL;
 };
 </script>


### PR DESCRIPTION
# 📌 카카오 로그인 기능 추가

<!-- 간단하고 명확한 PR 제목을 작성해주세요. -->

---

## 📝 변경 내용

- 카카오 로그인 기능을 추가했습니다.

---

## ✅ 체크리스트

- [x] 카카오 로그인 기능이 잘 되는지 확인했습니다. 

---

## 📷 스크린샷(선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

---

## 💬 기타 참고 사항

<!-- 추가로 논의할 내용이나 특이사항이 있다면 작성해주세요. -->
1. 카카오에서 제공한 로그인 URL로 리디렉션을 시킵니다.
2. 리디렉션된 페이지에서 카카오 로그인을 하면 카카오에서 검증된 code를 쿼리 스트링으로 전달해주면서 설정한 Redirect_uri로 이동됩니다.
3. 전달 받은 쿼리 스트링으로 Redirect_uri인, 임시 페이지(저희는 로딩 페이지,`/kakao`)에서 code와 함께 백엔드에 요청을 보내 로그인에 필요한 토큰들을 받습니다.
4. 이후에는 기존의 로그인 로직과 똑같이 진행됩니다.